### PR TITLE
chore: Rename Nmspaces to Namespaces

### DIFF
--- a/views/overview/summary_panel.go
+++ b/views/overview/summary_panel.go
@@ -130,7 +130,7 @@ func (p *clusterSummaryPanel) DrawBody(data interface{}) {
 		)
 		p.summaryTable.SetCell(
 			0, 2,
-			tview.NewTableCell(fmt.Sprintf("Nmspaces: [white]%d[white]", summary.Namespaces)).
+			tview.NewTableCell(fmt.Sprintf("Namespaces: [white]%d[white]", summary.Namespaces)).
 				SetTextColor(tcell.ColorYellow).
 				SetAlign(tview.AlignLeft).
 				SetExpansion(100),


### PR DESCRIPTION
Hi,

not sure if it's intentional or a spelling error:
![image](https://user-images.githubusercontent.com/38325136/148701452-be649bf1-f6af-4c1f-bbed-019876f3c500.png)

But this PR renames it to 
![image](https://user-images.githubusercontent.com/38325136/148701542-d8c87455-8fc3-49dd-bcb1-4460c1adf3c7.png)

BTW: love ktop!
