### PR TITLE
Metrics-api informer/lister

### DIFF
--- a/hack/kwok/kwok-deployments.yaml
+++ b/hack/kwok/kwok-deployments.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-web-1
+  namespace: default
+spec:
+  replicas: 100
+  selector:
+    matchLabels:
+      app: fake-web-1
+  template:
+    metadata:
+      labels:
+        app: fake-web-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - kwok
+      # A taints was added to an automatically created Node.
+      # You can remove taints of Node or add this tolerations.
+      tolerations:
+        - key: "kwok.x-k8s.io/node"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: fake-container
+          image: fake-image
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-web-2
+  namespace: default
+spec:
+  replicas: 50
+  selector:
+    matchLabels:
+      app: fake-web-2
+  template:
+    metadata:
+      labels:
+        app: fake-web-2
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - kwok
+      # A taints was added to an automatically created Node.
+      # You can remove taints of Node or add this tolerations.
+      tolerations:
+        - key: "kwok.x-k8s.io/node"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: fake-container
+          image: fake-image
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-backend-1
+  namespace: default
+spec:
+  replicas: 25
+  selector:
+    matchLabels:
+      app: fake-backend-1
+  template:
+    metadata:
+      labels:
+        app: fake-backend-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - kwok
+      # A taints was added to an automatically created Node.
+      # You can remove taints of Node or add this tolerations.
+      tolerations:
+        - key: "kwok.x-k8s.io/node"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: fake-container
+          image: fake-image
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-backend-2
+  namespace: default
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: fake-backend-2
+  template:
+    metadata:
+      labels:
+        app: fake-backend-2
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - kwok
+      # A taints was added to an automatically created Node.
+      # You can remove taints of Node or add this tolerations.
+      tolerations:
+        - key: "kwok.x-k8s.io/node"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: fake-container
+          image: fake-image

--- a/hack/kwok/kwok-nodes.yaml
+++ b/hack/kwok/kwok-nodes.yaml
@@ -1,0 +1,300 @@
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-0
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-0
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-1
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-1
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-2
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-2
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-3
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-3
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-4
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-4
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-5
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-5
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-6
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-6
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running

--- a/hack/kwok/kwok.sh
+++ b/hack/kwok/kwok.sh
@@ -1,0 +1,7 @@
+#! /bin/bash 
+
+kwok \
+  --kubeconfig=~/.kube/config \
+  --manage-all-nodes=true \
+  --cidr=10.0.0.1/24 \
+  --node-ip=10.0.0.1

--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -2,6 +2,6 @@
 
 minikube start --nodes 2 --memory=4096 --cpus=2 \
   --kubernetes-version=v1.23.1 \
-  --vm-driver=hyperkit \
+  --vm-driver=docker \
   --bootstrapper=kubeadm \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -9,25 +9,22 @@ import (
 	appsV1 "k8s.io/api/apps/v1"
 	authzV1 "k8s.io/api/authorization/v1"
 	batchV1 "k8s.io/api/batch/v1"
-	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
-	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 const (
-	AllNamespaces = ""
+	AllNamespaces = metav1.NamespaceAll
 )
 
 var (
@@ -58,7 +55,6 @@ type Client struct {
 	clusterContext    string
 	username          string
 	kubeClient        kubernetes.Interface
-	dynaClient        dynamic.Interface
 	discoClient       discovery.CachedDiscoveryInterface
 	metricsClient     *metricsclient.Clientset
 	metricsAvailCount int
@@ -166,54 +162,17 @@ func (k8s *Client) AssertMetricsAvailable() error {
 	for _, group := range groups.Groups {
 		if group.Name == metricsapi.GroupName {
 			avail = true
+			break
 		}
 	}
 
 	if !avail {
 		return fmt.Errorf("metrics api not available")
 	}
+
+	k8s.metricsAvailCount++
+
 	return nil
-}
-
-// GetNodeMetrics returns metrics for specified node
-func (k8s *Client) GetNodeMetrics(ctx context.Context, nodeName string) (*metricsV1beta1.NodeMetrics, error) {
-	if err := k8s.AssertMetricsAvailable(); err != nil {
-		return nil, fmt.Errorf("node metrics: %s", err)
-	}
-
-	metrics, err := k8s.metricsClient.MetricsV1beta1().NodeMetricses().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return metrics, nil
-}
-
-// GetPodMetricsByName returns metrics for specified pod
-func (k8s *Client) GetPodMetricsByName(ctx context.Context, pod *coreV1.Pod) (*metricsV1beta1.PodMetrics, error) {
-	if err := k8s.AssertMetricsAvailable(); err != nil {
-		return nil, fmt.Errorf("pod metrics by name: %s", err)
-	}
-
-	metrics, err := k8s.metricsClient.MetricsV1beta1().PodMetricses(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return metrics, nil
-}
-
-func (k8s *Client) GetAllPodMetrics(ctx context.Context) ([]metricsV1beta1.PodMetrics, error) {
-	if err := k8s.AssertMetricsAvailable(); err != nil {
-		return nil, fmt.Errorf("pod metrics: %s", err)
-	}
-
-	metricsList, err := k8s.metricsClient.MetricsV1beta1().PodMetricses(k8s.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return metricsList.Items, nil
 }
 
 func (k8s *Client) Controller() *Controller {

--- a/k8s/metrics_controller.go
+++ b/k8s/metrics_controller.go
@@ -1,0 +1,52 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+// GetNodeMetrics returns metrics for specified node
+func (c *Controller) GetNodeMetrics(ctx context.Context, nodeName string) (*metricsV1beta1.NodeMetrics, error) {
+	if err := c.client.AssertMetricsAvailable(); err != nil {
+		return nil, fmt.Errorf("node metrics: %s", err)
+	}
+
+	metrics, err := c.nodeMetricsInformer.Lister().Get(nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics, nil
+}
+
+// GetPodMetricsByName returns pod metrics for specified pod
+func (c *Controller) GetPodMetricsByName(ctx context.Context, pod *v1.Pod) (*metricsV1beta1.PodMetrics, error) {
+	if err := c.client.AssertMetricsAvailable(); err != nil {
+		return nil, fmt.Errorf("pod metrics by name: %s", err)
+	}
+
+	metrics, err := c.podMetricsInformer.Lister().Get(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics, nil
+}
+
+// GetAllPodMetrics retrieve all available pod emtrics
+func (c *Controller) GetAllPodMetrics(ctx context.Context) ([]*metricsV1beta1.PodMetrics, error) {
+	if err := c.client.AssertMetricsAvailable(); err != nil {
+		return nil, fmt.Errorf("all pod metrics: %s", err)
+	}
+
+	metricsList, err := c.podMetricsInformer.Lister().List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	return metricsList, nil
+}

--- a/k8s/metrics_informer.go
+++ b/k8s/metrics_informer.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"context"
+	time "time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+type NodeMetricsInformer struct {
+	client   metricsclient.Interface
+	informer cache.SharedIndexInformer
+	lister   *NodeMetricsLister
+}
+
+func NewNodeMetricsInformer(client metricsclient.Interface, resyncPeriod time.Duration) *NodeMetricsInformer {
+	informer := cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return client.MetricsV1beta1().NodeMetricses().List(context.TODO(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+
+				return client.MetricsV1beta1().NodeMetricses().Watch(context.TODO(), options)
+			},
+		},
+		&metricsV1beta1.NodeMetrics{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	return &NodeMetricsInformer{client: client, informer: informer}
+}
+
+func (i *NodeMetricsInformer) Informer() cache.SharedIndexInformer {
+	return i.informer
+}
+
+func (i *NodeMetricsInformer) Lister() *NodeMetricsLister {
+	if i.lister != nil {
+		return i.lister
+	}
+	i.lister = NewNodeMetricsLister(i.informer.GetIndexer())
+	return i.lister
+}
+
+type PodMetricsInformer struct {
+	client   metricsclient.Interface
+	informer cache.SharedIndexInformer
+	lister   *PodMetricsLister
+}
+
+func NewPodMetricsInformer(client metricsclient.Interface, resyncPeriod time.Duration, namespace string) *PodMetricsInformer {
+	informer := cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return client.MetricsV1beta1().PodMetricses(namespace).List(context.TODO(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return client.MetricsV1beta1().PodMetricses(namespace).Watch(context.TODO(), options)
+			},
+		},
+		&metricsV1beta1.PodMetrics{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	return &PodMetricsInformer{client: client, informer: informer}
+}
+
+func (i *PodMetricsInformer) Informer() cache.SharedIndexInformer {
+	return i.informer
+}
+
+func (i *PodMetricsInformer) Lister() *PodMetricsLister {
+	if i.lister != nil {
+		return i.lister
+	}
+	i.lister = NewPodMetricsLister(i.informer.GetIndexer())
+	return i.lister
+}

--- a/k8s/metrics_lister.go
+++ b/k8s/metrics_lister.go
@@ -1,0 +1,61 @@
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+type NodeMetricsLister struct {
+	indexer cache.Indexer
+}
+
+func NewNodeMetricsLister(indexer cache.Indexer) *NodeMetricsLister {
+	return &NodeMetricsLister{indexer: indexer}
+}
+
+func (s *NodeMetricsLister) List(selector labels.Selector) (ret []*metricsV1beta1.NodeMetrics, err error) {
+	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*metricsV1beta1.NodeMetrics))
+	})
+	return ret, err
+}
+
+func (s *NodeMetricsLister) Get(name string) (*metricsV1beta1.NodeMetrics, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(v1.Resource("nodemetrics"), name)
+	}
+	return obj.(*metricsV1beta1.NodeMetrics), nil
+}
+
+type PodMetricsLister struct {
+	indexer cache.Indexer
+}
+
+func NewPodMetricsLister(indexer cache.Indexer) *PodMetricsLister {
+	return &PodMetricsLister{indexer: indexer}
+}
+
+func (s *PodMetricsLister) List(selector labels.Selector) (ret []*metricsV1beta1.PodMetrics, err error) {
+	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*metricsV1beta1.PodMetrics))
+	})
+	return ret, err
+}
+
+func (s *PodMetricsLister) Get(pod *v1.Pod) (*metricsV1beta1.PodMetrics, error) {
+	obj, exists, err := s.indexer.GetByKey(pod.Namespace + "/" + pod.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(v1.Resource("podmetrics"), pod.Name)
+	}
+	return obj.(*metricsV1beta1.PodMetrics), nil
+}

--- a/k8s/nodes_controller.go
+++ b/k8s/nodes_controller.go
@@ -52,7 +52,7 @@ func (c *Controller) GetNodeModels(ctx context.Context) (models []model.NodeMode
 	}
 
 	for _, node := range nodes {
-		metrics, err := c.client.GetNodeMetrics(ctx, node.Name)
+		metrics, err := c.GetNodeMetrics(ctx, node.Name)
 		if err != nil {
 			metrics = new(metricsV1beta1.NodeMetrics)
 		}

--- a/k8s/pods_controller.go
+++ b/k8s/pods_controller.go
@@ -30,14 +30,15 @@ func (c *Controller) GetPodModels(ctx context.Context) (models []model.PodModel,
 	nodeAllocResMap := make(map[string]coreV1.ResourceList)
 	for _, pod := range pods {
 
-		// retrieve metrics for pod
-		podMetrics, err := c.client.GetPodMetricsByName(ctx, pod)
+		// retrieve metrics per pod
+		podMetrics, err := c.GetPodMetricsByName(ctx, pod)
 		if err != nil {
 			podMetrics = new(metricsV1beta1.PodMetrics)
 		}
 
+		// retrieve and cache node metrics for related pod-node
 		if metrics, ok := nodeMetricsCache[pod.Spec.NodeName]; !ok {
-			metrics, err = c.client.GetNodeMetrics(ctx, pod.Spec.NodeName)
+			metrics, err = c.GetNodeMetrics(ctx, pod.Spec.NodeName)
 			if err != nil {
 				metrics = new(metricsV1beta1.NodeMetrics)
 			}
@@ -52,7 +53,7 @@ func (c *Controller) GetPodModels(ctx context.Context) (models []model.PodModel,
 			node, err := c.GetNode(ctx, pod.Spec.NodeName)
 			if err != nil {
 				alloc = coreV1.ResourceList{}
-			}else{
+			} else {
 				alloc = node.Status.Allocatable
 			}
 			nodeAllocResMap[pod.Spec.NodeName] = alloc

--- a/k8s/summary_controller.go
+++ b/k8s/summary_controller.go
@@ -64,7 +64,7 @@ func (c *Controller) refreshSummary(ctx context.Context, handlerFunc RefreshSumm
 		summary.AllocatableNodeMemTotal.Add(*node.Status.Allocatable.Memory())
 		summary.AllocatableNodeCpuTotal.Add(*node.Status.Allocatable.Cpu())
 
-		metrics, err := c.client.GetNodeMetrics(ctx, node.Name)
+		metrics, err := c.GetNodeMetrics(ctx, node.Name)
 		if err != nil {
 			metrics = new(metricsV1beta1.NodeMetrics)
 		}

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -53,7 +53,7 @@ func (p *MainPanel) Layout(data interface{}) {
 
 	view := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(p.clusterSummaryPanel.GetRootView(), 4, 1, true).
-		AddItem(p.nodePanel.GetRootView(), 7, 1, true).
+		AddItem(p.nodePanel.GetRootView(), 15, 1, true).
 		AddItem(p.podPanel.GetRootView(), 0, 1, true)
 
 	p.root = view


### PR DESCRIPTION
This PR implements an informer for the metrics-api data to enable better scaling.
Now, instead of retrieving data with each refresh, the data is cached using the client-go informer.

Possibly fixes #19 