### PR TITLE
chore: fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: ktop
 
 release:
@@ -99,7 +100,7 @@ brews:
   - name: ktop
     ids:
     - ktop
-    tap:
+    repository:
       owner: vladimirvivien
       name: homebrew-oss-tools
     commit_author:


### PR DESCRIPTION
Fixed the release error.

https://github.com/vladimirvivien/ktop/actions/runs/9842852649/job/27172722476

```
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```

https://goreleaser.com/deprecations/#brewstap

## Test

`goreleaser check` succeeded.

<details>
<summary>$ goreleaser -v</summary>

```console
goreleaser -v
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    2.0.1
GitCommit:     684c1805864e5f29acc204e34e1770eb74918d15
GitTreeState:  false
BuildDate:     2024-06-11T01:45:52Z
BuiltBy:       goreleaser
GoVersion:     go1.22.4
Compiler:      gc
ModuleSum:     h1:Wx2peRnvixEBRKxU6T0Gh+3wlire+Jv2IOW5eNPan3U=
Platform:      darwin/arm64
```

</details>

```console
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```