### PR TITLE
Bugfix/memory graph

### DIFF
--- a/views/model/pod_model.go
+++ b/views/model/pod_model.go
@@ -158,14 +158,14 @@ func GetPodContainerSummary(pod *v1.Pod) PodContainerSummary {
 
 	for _, container := range pod.Spec.InitContainers {
 		mems.Add(*container.Resources.Requests.Memory())
-		mems.Add(*container.Resources.Requests.Cpu())
+		cpus.Add(*container.Resources.Requests.Cpu())
 		ports += len(container.Ports)
 		mounts += len(container.VolumeMounts)
 	}
 
 	if pod.Spec.Overhead != nil {
 		mems.Add(*pod.Spec.Overhead.Memory())
-		mems.Add(*pod.Spec.Overhead.Cpu())
+		cpus.Add(*pod.Spec.Overhead.Cpu())
 	}
 
 	return PodContainerSummary{

--- a/views/overview/pod_panel.go
+++ b/views/overview/pod_panel.go
@@ -18,7 +18,8 @@ type podPanel struct {
 	children []tview.Primitive
 	listCols []string
 	list     *tview.Table
-	laidout bool
+	laidout  bool
+	colMap   map[string]int // Maps column name to position index
 }
 
 func NewPodPanel(app *application.Application, title string) ui.Panel {
@@ -61,7 +62,11 @@ func (p *podPanel) DrawHeader(data interface{}) {
 		panic(fmt.Sprintf("podPanel.DrawBody got unexpected data type %T", data))
 	}
 
+	// Initialize the column map
+	p.colMap = make(map[string]int)
 	p.listCols = cols
+	
+	// Set column headers and build column map
 	for i, col := range p.listCols {
 		p.list.SetCell(0, i,
 			tview.NewTableCell(col).
@@ -71,6 +76,9 @@ func (p *podPanel) DrawHeader(data interface{}) {
 				SetExpansion(100).
 				SetSelectable(false),
 		)
+		
+		// Map column name to position
+		p.colMap[col] = i
 	}
 	p.list.SetFixed(1, 0)
 }
@@ -91,134 +99,202 @@ func (p *podPanel) DrawBody(data interface{}) {
 	p.root.SetTitle(fmt.Sprintf("%s(%d) ", p.GetTitle(), len(pods)))
 	p.root.SetTitleAlign(tview.AlignLeft)
 
-	for i, pod := range pods {
-		i++ // offset to n+1
-		p.list.SetCell(
-			i, 0,
-			&tview.TableCell{
-				Text:  pod.Namespace,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 1,
-			&tview.TableCell{
-				Text:  pod.Name,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 2,
-			&tview.TableCell{
-				Text:  fmt.Sprintf("%d/%d", pod.ReadyContainers, pod.TotalContainers),
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 3,
-			&tview.TableCell{
-				Text:  pod.Status,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 4,
-			&tview.TableCell{
-				Text:  fmt.Sprintf("%d", pod.Restarts),
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 5,
-			&tview.TableCell{
-				Text:  pod.TimeSince,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		// Volume
-		p.list.SetCell(
-			i, 6,
-			&tview.TableCell{
-				Text:  fmt.Sprintf("%d/%d", pod.Volumes, pod.VolMounts),
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 7,
-			&tview.TableCell{
-				Text:  pod.IP,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 8,
-			&tview.TableCell{
-				Text:  pod.Node,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		if metricsDisabled {
-			cpuRatio = ui.GetRatio(float64(pod.PodRequestedCpuQty.MilliValue()), float64(pod.NodeAllocatableCpuQty.MilliValue()))
-			cpuGraph = ui.BarGraph(10, cpuRatio, colorKeys)
-			cpuMetrics = fmt.Sprintf(
-				"[white][%s[white]] %dm %02.1f%%",
-				cpuGraph, pod.PodRequestedCpuQty.MilliValue(), cpuRatio*100,
-			)
-
-			memRatio = ui.GetRatio(float64(pod.PodRequestedMemQty.MilliValue()), float64(pod.NodeAllocatableMemQty.MilliValue()))
-			memGraph = ui.BarGraph(10, memRatio, colorKeys)
-			memMetrics = fmt.Sprintf(
-				"[white][%s[white]] %dGi %02.1f%%", memGraph, pod.PodRequestedMemQty.ScaledValue(resource.Giga), memRatio*100,
-			)
-		} else {
-			cpuRatio = ui.GetRatio(float64(pod.PodUsageCpuQty.MilliValue()), float64(pod.NodeAllocatableCpuQty.MilliValue()))
-			cpuGraph = ui.BarGraph(10, cpuRatio, colorKeys)
-			cpuMetrics = fmt.Sprintf("[white][%s[white]] %dm %02.1f%%", cpuGraph, pod.PodUsageCpuQty.MilliValue(), cpuRatio*100)
-
-			memRatio = ui.GetRatio(float64(pod.PodUsageMemQty.MilliValue()), float64(pod.NodeUsageMemQty.MilliValue()))
-			memGraph = ui.BarGraph(10, memRatio, colorKeys)
-			memMetrics = fmt.Sprintf("[white][%s[white]] %dMi %02.1f%%", memGraph, pod.PodUsageMemQty.ScaledValue(resource.Mega), memRatio*100)
+	for rowIdx, pod := range pods {
+		rowIdx++ // offset for header row
+		
+		// Render each column that is included in the filtered view
+		for _, colName := range p.listCols {
+			colIdx, exists := p.colMap[colName]
+			if !exists {
+				continue
+			}
+			
+			switch colName {
+			case "NAMESPACE":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.Namespace,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "POD":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.Name,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "READY":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  fmt.Sprintf("%d/%d", pod.ReadyContainers, pod.TotalContainers),
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "STATUS":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.Status,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "RESTARTS":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  fmt.Sprintf("%d", pod.Restarts),
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "AGE":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.TimeSince,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "VOLS":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  fmt.Sprintf("%d", pod.Volumes),
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "IP":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.IP,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "NODE":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:  pod.Node,
+						Color: tcell.ColorYellow,
+						Align: tview.AlignLeft,
+					},
+				)
+				
+			case "CPU":
+				if metricsDisabled {
+					// no CPU metrics
+					p.list.SetCell(
+						rowIdx, colIdx,
+						&tview.TableCell{
+							Text:  "unavailable",
+							Color: tcell.ColorYellow,
+							Align: tview.AlignLeft,
+						},
+					)
+				} else {
+					// Check if CPU limit is set (non-zero), otherwise use node limit
+					var cpuDenominator float64
+					var cpuLimitLabel string
+					
+					if pod.PodLimitCpuQty != nil && pod.PodLimitCpuQty.MilliValue() > 0 {
+						// Use pod limit
+						cpuDenominator = float64(pod.PodLimitCpuQty.MilliValue())
+						cpuLimitLabel = fmt.Sprintf("%dm", pod.PodLimitCpuQty.MilliValue())
+					} else {
+						// Use node limit when pod limit is not set
+						cpuDenominator = float64(pod.NodeAllocatableCpuQty.MilliValue())
+						cpuLimitLabel = fmt.Sprintf("%dm*", pod.NodeAllocatableCpuQty.MilliValue())
+					}
+					
+					cpuRatio = ui.GetRatio(float64(pod.PodUsageCpuQty.MilliValue()), cpuDenominator)
+					cpuGraph = ui.BarGraph(10, cpuRatio, colorKeys)
+					cpuMetrics = fmt.Sprintf(
+						"[white][%s[white]] %dm/%s (%1.0f%%)",
+						cpuGraph, pod.PodUsageCpuQty.MilliValue(), cpuLimitLabel, cpuRatio*100,
+					)
+					p.list.SetCell(
+						rowIdx, colIdx,
+						&tview.TableCell{
+							Text:  cpuMetrics,
+							Color: tcell.ColorYellow,
+							Align: tview.AlignLeft,
+						},
+					)
+				}
+				
+			case "MEMORY":
+				if metricsDisabled {
+					// no Memory metrics
+					p.list.SetCell(
+						rowIdx, colIdx,
+						&tview.TableCell{
+							Text:  "unavailable",
+							Color: tcell.ColorYellow,
+							Align: tview.AlignLeft,
+						},
+					)
+				} else {
+					// Check if memory limit is set (non-zero), otherwise use node limit
+					var memDenominator float64
+					var memLimitLabel string
+					var memLimitScaled int64
+					
+					if pod.PodLimitMemQty != nil && pod.PodLimitMemQty.Value() > 0 {
+						// Use pod limit
+						memDenominator = float64(pod.PodLimitMemQty.Value())
+						memLimitScaled = pod.PodLimitMemQty.ScaledValue(resource.Mega)
+						memLimitLabel = fmt.Sprintf("%dMi", memLimitScaled)
+					} else {
+						// Use node limit when pod limit is not set
+						memDenominator = float64(pod.NodeAllocatableMemQty.Value())
+						memLimitScaled = pod.NodeAllocatableMemQty.ScaledValue(resource.Mega)
+						memLimitLabel = fmt.Sprintf("%dMi*", memLimitScaled)
+					}
+					
+					memRatio = ui.GetRatio(float64(pod.PodUsageMemQty.Value()), memDenominator)
+					memGraph = ui.BarGraph(10, memRatio, colorKeys)
+					memMetrics = fmt.Sprintf(
+						"[white][%s[white]] %dMi/%s (%1.0f%%)",
+						memGraph, 
+						pod.PodUsageMemQty.ScaledValue(resource.Mega), 
+						memLimitLabel, 
+						memRatio*100,
+					)
+					p.list.SetCell(
+						rowIdx, colIdx,
+						&tview.TableCell{
+							Text:  memMetrics,
+							Color: tcell.ColorYellow,
+							Align: tview.AlignLeft,
+						},
+					)
+				}
+			}
 		}
-
-		p.list.SetCell(
-			i, 9,
-			&tview.TableCell{
-				Text:  cpuMetrics,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
-
-		p.list.SetCell(
-			i, 10,
-			&tview.TableCell{
-				Text:  memMetrics,
-				Color: tcell.ColorYellow,
-				Align: tview.AlignLeft,
-			},
-		)
 	}
 }
 
-func (p *podPanel) DrawFooter(data interface{}) {}
+func (p *podPanel) DrawFooter(_ interface{}) {}
 
 func (p *podPanel) Clear() {
 	p.list.Clear()


### PR DESCRIPTION
  1. Updated the PodModel and PodContainerSummary structures:
    - Added fields to store memory limit information: PodLimitMemQty and PodLimitCpuQty
  2. Enhanced GetPodContainerSummary function:
    - Fixed bugs that were incorrectly adding CPU values to memory totals
    - Added proper handling for collecting memory limits from containers

  3. Updated memory progress bar display:
    - Changed the memory usage ratio calculation to use: usage / limit instead of usage / request

  4. Ensured compatibility with column filtering:
    - Integrated the improvements with the column filtering feature
  
5. CPU Resource Calculation:
    - Added logic to check if the pod CPU limit is set (non-zero)
    - If limit is set, use the pod's CPU limit for calculation
    - If limit is not set or zero, fall back to using the node's allocatable CPU capacity
    - Added an asterisk (*) to the display to indicate when node limit is being used
6. Memory Resource Calculation:
    - Added similar logic for memory resources
    - Check if pod memory limit is set and valid
    - If not set, fall back to node allocatable memory
    - Also added an asterisk to indicate when node limits are being used
