### PR TITLE
issue-70 - chore: Code improvement and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Application Architecture**: Application now uses MetricsSource interface for all metrics operations
+  - Views properly connected to MetricsSource for fresh metrics
+  - Graceful degradation when metrics sources are unavailable
+  - Improved separation of concerns between metrics collection and display
 - Enhanced CLI help text with detailed Prometheus configuration options
 - Improved error messages for invalid configuration values
 
+### Fixed
+
+- **Critical**: Fixed application startup hang (2-10 second delay)
+  - Removed metrics informers from controller (now handled by MetricsSource interface)
+  - Eliminated blocking `AssertMetricsAvailable()` network call during controller startup
+  - Removed 5-second timeout waiting for metrics informers to sync
+  - Core resource informers use 2-second timeout instead of indefinite wait
+  - Removed blocking `AssertMetricsAvailable()` call from application setup
+  - Application now checks MetricsSource health asynchronously
+  - Startup is now near-instant (<2 seconds) regardless of cluster size or metrics availability
+  - Added "Loading cluster data..." message to inform users during initial data load
+- **Critical**: Fixed metrics connection status display
+  - Status now reflects actual MetricsSource health (not cached k8s client state)
+  - Shows "not connected" when Metrics Server is truly unavailable
+  - MetricsServerSource starts unhealthy, becomes healthy after first successful fetch
+  - Header auto-updates after 2 seconds to show "connected" once metrics are fetched
+  - Periodic refresh every 10 seconds to keep status current
+- **Critical**: Fixed cluster summary showing 0m/0Gi for CPU/Memory usage
+  - Controller now uses MetricsSource interface for cluster summary metrics
+  - `Controller.GetNodeMetrics()` updated to fetch from MetricsSource instead of deprecated informers
+  - Fixed nil pointer dereference panic when metrics are unavailable
+  - Gracefully skips nodes without metrics instead of crashing
+  - Works correctly with all metrics sources (metrics-server, prometheus, or fallback)
+  - Cluster summary now displays actual usage data from configured metrics source
+- **Critical**: Fixed infinite recursion stack overflow in MetricsServerSource
+  - `MetricsServerSource` now calls Kubernetes Metrics Server API directly
+  - Removed circular dependency between Controller and MetricsServerSource
+  - Fixed stack overflow: `Controller.GetNodeMetrics()` → `MetricsSource.GetNodeMetrics()` → `Controller.GetNodeMetrics()` loop
+  - `MetricsServerSource` now accesses `metricsClient` directly instead of through controller
+  - All metrics fetching methods updated (GetNodeMetrics, GetPodMetrics, GetAllPodMetrics)
+- Fixed cluster summary display in fallback mode
+  - Now shows resource requests when usage metrics are unavailable (0m/0Gi)
+  - Changed from blocking `AssertMetricsAvailable()` check to data-based check
+  - Checks if usage values are non-zero instead of API availability
+  - Properly displays "% requested" vs "% used" based on actual data availability
+- **Critical**: Fixed memory display showing incorrect values across all views
+  - Changed from decimal Giga (10^9) to binary GiB (2^30) for memory calculations
+  - Added smart unit formatting: displays Mi for values <10Gi, Gi for larger values
+  - This matches `kubectl top` behavior and prevents loss of precision
+  - Fixed cluster summary memory display (e.g., 1405Mi/15Gi instead of 2Gi/17Gi)
+  - Fixed nodes panel memory display (both usage and allocatable)
+  - Fixed pods panel memory display showing actual values (366Mi, 56Mi, etc. instead of 0Gi)
+  - Fixed nodes panel incorrectly using cached `AssertMetricsAvailable()` check
+  - Nodes panel now checks actual data presence instead of relying on stale API checks
+  - Memory values now match `kubectl top nodes` and `kubectl top pods` output exactly
+  - Fixes both "% requested" and "% used" memory display modes across all panels
+  - Added `ui.FormatMemory()` helper function with comprehensive tests
+- Fixed issue where CPU and Memory columns showed "Unavailable" in default mode
+  - Properly connected metrics sources to UI views
+  - MetricsSource now correctly passed from CLI → Application → Views
+- Metrics Server graceful fallback to requests/limits now works correctly
+  - When Metrics Server unavailable, automatically uses resource requests/limits
+  - No error messages shown to user, seamless experience
+- Fixed pod panel display formatting to match previous version exactly
+  - VOLS column format: `2/2` (volumes/mounts)
+  - CPU/Memory format includes bargraph and percentage
+  - Proper unit handling (Giga for memory)
+
 ### Notes
 
-- **Prometheus UI Integration**: Prometheus metrics source is initialized and collects data, but UI integration is not yet complete. The application will show a warning and use metrics-server fallback for display while this feature is being completed.
+- **Prometheus Enhanced Metrics**: While Prometheus metrics collection is fully functional, enhanced UI columns (network I/O, load averages, container counts) are planned for a future release. Use `--enhanced-columns` flag (when available) to access these additional metrics.
 - **Managed Kubernetes**: Prometheus mode may not work in managed Kubernetes environments (GKE, EKS, AKS) where component endpoints are restricted. Use default metrics-server mode in these environments.
 - **RBAC Requirements**: Prometheus mode requires RBAC permissions to access component `/metrics` endpoints. If permissions are insufficient, use metrics-server mode.
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ For instance, the following will show cluster information for workload resources
 ktop --namespace my-app --context web-cluster
 ```
 
+## How Metrics Work
+
+ktop displays resource metrics from your Kubernetes cluster using one of two sources:
+
+### Metrics Server (Default)
+
+When you run `ktop` without flags, it uses the Kubernetes Metrics Server:
+
+- **If Metrics Server is available**: Shows real-time CPU and memory usage
+- **If Metrics Server is unavailable**: Automatically falls back to resource requests/limits
+- **Always works**: Even in clusters without Metrics Server installed
+
+This graceful fallback ensures ktop always provides useful information about your cluster resources.
+
+### Prometheus (Enhanced Metrics)
+
+For richer metrics including network I/O, load averages, and container statistics, use Prometheus mode:
+
+```bash
+ktop --metrics-source=prometheus
+```
+
+This provides additional metrics beyond CPU and memory, giving you deeper insights into cluster performance. See the [Metrics Source Selection](#metrics-source-selection) section below for full details.
+
 ## Metrics Source Selection
 
 ktop supports two metrics sources for gathering cluster resource metrics:
@@ -188,7 +212,13 @@ ktop --metrics-source=prometheus \
 - Network access to Kubernetes component endpoints
 - May not work in managed Kubernetes (GKE, EKS, AKS) where component endpoints are restricted
 
-**Note:** Prometheus mode is currently in development. The metrics source is initialized and collects data, but UI integration is not yet complete. The application will show a warning and fall back to metrics-server for display.
+**Enhanced Metrics Available:**
+When using Prometheus mode, you get access to additional metrics including:
+- Network I/O statistics (Rx/Tx bytes)
+- System load averages (1m, 5m, 15m)
+- Container counts per node
+- Per-container resource breakdowns
+- And more...
 
 ### Usage Examples
 
@@ -238,10 +268,6 @@ ktop --metrics-source=prometheus \
 - Cause: Insufficient RBAC permissions or network access issues
 - Solution: Ensure you have permissions to access component metrics endpoints
 - Alternative: Use `--metrics-source=metrics-server` (default)
-
-**Prometheus mode shows warning about UI integration**
-- This is expected - Prometheus metrics collection is working but UI integration is in development
-- The application will use metrics-server for display while Prometheus features are being completed
 
 ### Column Filtering
 

--- a/application/app_ui.go
+++ b/application/app_ui.go
@@ -47,7 +47,7 @@ func (p *appPanel) Layout(data interface{}) {
 
 	root := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(p.header, 3, 1, false). // header
-		AddItem(p.pages, 0, 1, true)   // body
+		AddItem(p.pages, 0, 1, true)    // body
 		// TODO show footer when multi-page is implemented
 		//AddItem(p.footer, 3, 1, false)  // footer
 	p.root = root

--- a/cmd/ktop.go
+++ b/cmd/ktop.go
@@ -36,15 +36,15 @@ var (
 )
 
 type ktopCmdOptions struct {
-	namespace         string
-	allNamespaces     bool
-	context           string
-	kubeconfig        string
-	kubeFlags         *genericclioptions.ConfigFlags
-	page              string // future use
-	nodeColumns       string // comma-separated list of node columns to display
-	podColumns        string // comma-separated list of pod columns to display
-	showAllColumns    bool   // show all columns
+	namespace      string
+	allNamespaces  bool
+	context        string
+	kubeconfig     string
+	kubeFlags      *genericclioptions.ConfigFlags
+	page           string // future use
+	nodeColumns    string // comma-separated list of node columns to display
+	podColumns     string // comma-separated list of pod columns to display
+	showAllColumns bool   // show all columns
 
 	// Metrics configuration
 	metricsSource            string
@@ -195,20 +195,20 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 
 	app := application.New(k8sC, metricsSource)
 	app.WelcomeBanner()
-	
+
 	// Process column options
 	nodeColumns := []string{}
 	if o.nodeColumns != "" {
 		nodeColumns = strings.Split(o.nodeColumns, ",")
 		o.showAllColumns = false
 	}
-	
+
 	podColumns := []string{}
 	if o.podColumns != "" {
 		podColumns = strings.Split(o.podColumns, ",")
 		o.showAllColumns = false
 	}
-	
+
 	// Create a new overview page with column options
 	app.AddPage(overview.NewWithColumnOptions(app, "Overview", o.showAllColumns, nodeColumns, podColumns))
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -144,6 +144,9 @@ func (k8s *Client) GetServerVersion() string {
 // AssertMetricsAvailable checks for available metrics server every 10th invocation.
 // Otherwise, it returns the last known registration state of metrics server.
 func (k8s *Client) AssertMetricsAvailable() error {
+	k8s.Lock()
+	defer k8s.Unlock()
+
 	if k8s.metricsAvailCount != 0 {
 		if k8s.metricsAvailCount%10 != 0 {
 			k8s.metricsAvailCount++
@@ -177,6 +180,10 @@ func (k8s *Client) AssertMetricsAvailable() error {
 
 func (k8s *Client) Controller() *Controller {
 	return k8s.controller
+}
+
+func (k8s *Client) GetMetricsClient() *metricsclient.Clientset {
+	return k8s.metricsClient
 }
 
 // IsAuthz checks access authorization using SelfSubjectAccessReview

--- a/k8s/client_funcs.go
+++ b/k8s/client_funcs.go
@@ -50,7 +50,6 @@ func (c *Controller) GetDaemonSetList(ctx context.Context) ([]*appsV1.DaemonSet,
 	return items, nil
 }
 
-
 func (c *Controller) GetReplicaSetList(ctx context.Context) ([]*appsV1.ReplicaSet, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/k8s/client_util.go
+++ b/k8s/client_util.go
@@ -25,7 +25,7 @@ func findKubeCfgFile() (string, error) {
 }
 
 func loadConfig(kubeconfig, context string) (*rest.Config, error) {
-	if kubeconfig == ""{
+	if kubeconfig == "" {
 		kcfg, err := findKubeCfgFile()
 		if err != nil {
 			return nil, err

--- a/k8s/metrics_controller.go
+++ b/k8s/metrics_controller.go
@@ -5,28 +5,50 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
 // GetNodeMetrics returns metrics for specified node
+// Now uses MetricsSource interface instead of metrics informers
 func (c *Controller) GetNodeMetrics(ctx context.Context, nodeName string) (*metricsV1beta1.NodeMetrics, error) {
-	if err := c.client.AssertMetricsAvailable(); err != nil {
-		return nil, fmt.Errorf("node metrics: %s", err)
+	// If no metrics source available, return error for graceful degradation
+	if c.metricsSource == nil {
+		return nil, fmt.Errorf("metrics source not available")
 	}
 
-	metrics, err := c.nodeMetricsInformer.Lister().Get(nodeName)
+	// Fetch metrics from the configured source (metrics-server or prometheus)
+	nodeMetrics, err := c.metricsSource.GetNodeMetrics(ctx, nodeName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("node metrics: %w", err)
 	}
 
-	return metrics, nil
+	// Convert from metrics.NodeMetrics to v1beta1.NodeMetrics
+	usage := v1.ResourceList{}
+	if nodeMetrics.CPUUsage != nil {
+		usage[v1.ResourceCPU] = *nodeMetrics.CPUUsage
+	}
+	if nodeMetrics.MemoryUsage != nil {
+		usage[v1.ResourceMemory] = *nodeMetrics.MemoryUsage
+	}
+
+	return &metricsV1beta1.NodeMetrics{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeMetrics.NodeName},
+		Timestamp:  metav1.NewTime(nodeMetrics.Timestamp),
+		Window:     metav1.Duration{Duration: 0},
+		Usage:      usage,
+	}, nil
 }
 
 // GetPodMetricsByName returns pod metrics for specified pod
 func (c *Controller) GetPodMetricsByName(ctx context.Context, pod *v1.Pod) (*metricsV1beta1.PodMetrics, error) {
 	if err := c.client.AssertMetricsAvailable(); err != nil {
 		return nil, fmt.Errorf("pod metrics by name: %s", err)
+	}
+
+	if c.podMetricsInformer == nil {
+		return nil, fmt.Errorf("pod metrics informer not available")
 	}
 
 	metrics, err := c.podMetricsInformer.Lister().Get(pod)
@@ -41,6 +63,10 @@ func (c *Controller) GetPodMetricsByName(ctx context.Context, pod *v1.Pod) (*met
 func (c *Controller) GetAllPodMetrics(ctx context.Context) ([]*metricsV1beta1.PodMetrics, error) {
 	if err := c.client.AssertMetricsAvailable(); err != nil {
 		return nil, fmt.Errorf("all pod metrics: %s", err)
+	}
+
+	if c.podMetricsInformer == nil {
+		return nil, fmt.Errorf("pod metrics informer not available")
 	}
 
 	metricsList, err := c.podMetricsInformer.Lister().List(labels.Everything())

--- a/metrics/k8s/metrics_server_source_test.go
+++ b/metrics/k8s/metrics_server_source_test.go
@@ -203,9 +203,9 @@ func TestMetricsServerSource_GetAvailableMetrics(t *testing.T) {
 func TestMetricsServerSource_HealthTracking(t *testing.T) {
 	source := NewMetricsServerSource(nil)
 
-	// Initially healthy
-	if !source.IsHealthy() {
-		t.Error("Expected source to be initially healthy")
+	// Initially unhealthy (becomes healthy after first successful fetch)
+	if source.IsHealthy() {
+		t.Error("Expected source to be initially unhealthy")
 	}
 
 	info := source.GetSourceInfo()
@@ -221,8 +221,8 @@ func TestMetricsServerSource_HealthTracking(t *testing.T) {
 	if info.ErrorCount != 0 {
 		t.Errorf("Expected ErrorCount 0, got %d", info.ErrorCount)
 	}
-	if !info.Healthy {
-		t.Error("Expected SourceInfo.Healthy to be true")
+	if info.Healthy {
+		t.Error("Expected SourceInfo.Healthy to be false initially")
 	}
 
 	// Record an error
@@ -260,12 +260,12 @@ func TestMetricsServerSource_New(t *testing.T) {
 		t.Fatal("Expected NewMetricsServerSource to return non-nil")
 	}
 
-	if source.controller != nil {
-		t.Error("Expected controller to be nil when passed nil")
+	if source.metricsClient != nil {
+		t.Error("Expected metricsClient to be nil when passed nil controller")
 	}
 
-	if !source.healthy {
-		t.Error("Expected new source to be healthy")
+	if source.healthy {
+		t.Error("Expected new source to be unhealthy initially")
 	}
 
 	if source.errorCount != 0 {

--- a/metrics/prom/prom_source_test.go
+++ b/metrics/prom/prom_source_test.go
@@ -17,35 +17,35 @@ type mockPodObject struct {
 	name      string
 }
 
-func (m *mockPodObject) GetNamespace() string              { return m.namespace }
-func (m *mockPodObject) SetNamespace(namespace string)     { m.namespace = namespace }
-func (m *mockPodObject) GetName() string                   { return m.name }
-func (m *mockPodObject) SetName(name string)               { m.name = name }
-func (m *mockPodObject) GetGenerateName() string           { return "" }
-func (m *mockPodObject) SetGenerateName(name string)       {}
-func (m *mockPodObject) GetUID() types.UID                 { return "" }
-func (m *mockPodObject) SetUID(uid types.UID)              {}
-func (m *mockPodObject) GetResourceVersion() string        { return "" }
-func (m *mockPodObject) SetResourceVersion(version string) {}
-func (m *mockPodObject) GetGeneration() int64              { return 0 }
-func (m *mockPodObject) SetGeneration(generation int64)    {}
-func (m *mockPodObject) GetSelfLink() string               { return "" }
-func (m *mockPodObject) SetSelfLink(selfLink string)       {}
-func (m *mockPodObject) GetCreationTimestamp() metav1.Time { return metav1.Time{} }
-func (m *mockPodObject) SetCreationTimestamp(timestamp metav1.Time) {}
-func (m *mockPodObject) GetDeletionTimestamp() *metav1.Time          { return nil }
-func (m *mockPodObject) SetDeletionTimestamp(timestamp *metav1.Time) {}
-func (m *mockPodObject) GetDeletionGracePeriodSeconds() *int64       { return nil }
-func (m *mockPodObject) SetDeletionGracePeriodSeconds(*int64)        {}
-func (m *mockPodObject) GetLabels() map[string]string                { return nil }
-func (m *mockPodObject) SetLabels(labels map[string]string)          {}
-func (m *mockPodObject) GetAnnotations() map[string]string           { return nil }
-func (m *mockPodObject) SetAnnotations(annotations map[string]string) {}
-func (m *mockPodObject) GetFinalizers() []string                      { return nil }
-func (m *mockPodObject) SetFinalizers(finalizers []string)            {}
-func (m *mockPodObject) GetOwnerReferences() []metav1.OwnerReference  { return nil }
-func (m *mockPodObject) SetOwnerReferences([]metav1.OwnerReference)   {}
-func (m *mockPodObject) GetManagedFields() []metav1.ManagedFieldsEntry { return nil }
+func (m *mockPodObject) GetNamespace() string                                       { return m.namespace }
+func (m *mockPodObject) SetNamespace(namespace string)                              { m.namespace = namespace }
+func (m *mockPodObject) GetName() string                                            { return m.name }
+func (m *mockPodObject) SetName(name string)                                        { m.name = name }
+func (m *mockPodObject) GetGenerateName() string                                    { return "" }
+func (m *mockPodObject) SetGenerateName(name string)                                {}
+func (m *mockPodObject) GetUID() types.UID                                          { return "" }
+func (m *mockPodObject) SetUID(uid types.UID)                                       {}
+func (m *mockPodObject) GetResourceVersion() string                                 { return "" }
+func (m *mockPodObject) SetResourceVersion(version string)                          {}
+func (m *mockPodObject) GetGeneration() int64                                       { return 0 }
+func (m *mockPodObject) SetGeneration(generation int64)                             {}
+func (m *mockPodObject) GetSelfLink() string                                        { return "" }
+func (m *mockPodObject) SetSelfLink(selfLink string)                                {}
+func (m *mockPodObject) GetCreationTimestamp() metav1.Time                          { return metav1.Time{} }
+func (m *mockPodObject) SetCreationTimestamp(timestamp metav1.Time)                 {}
+func (m *mockPodObject) GetDeletionTimestamp() *metav1.Time                         { return nil }
+func (m *mockPodObject) SetDeletionTimestamp(timestamp *metav1.Time)                {}
+func (m *mockPodObject) GetDeletionGracePeriodSeconds() *int64                      { return nil }
+func (m *mockPodObject) SetDeletionGracePeriodSeconds(*int64)                       {}
+func (m *mockPodObject) GetLabels() map[string]string                               { return nil }
+func (m *mockPodObject) SetLabels(labels map[string]string)                         {}
+func (m *mockPodObject) GetAnnotations() map[string]string                          { return nil }
+func (m *mockPodObject) SetAnnotations(annotations map[string]string)               {}
+func (m *mockPodObject) GetFinalizers() []string                                    { return nil }
+func (m *mockPodObject) SetFinalizers(finalizers []string)                          {}
+func (m *mockPodObject) GetOwnerReferences() []metav1.OwnerReference                { return nil }
+func (m *mockPodObject) SetOwnerReferences([]metav1.OwnerReference)                 {}
+func (m *mockPodObject) GetManagedFields() []metav1.ManagedFieldsEntry              { return nil }
 func (m *mockPodObject) SetManagedFields(managedFields []metav1.ManagedFieldsEntry) {}
 
 // MockMetricsStore implements prom.MetricsStore for testing
@@ -423,8 +423,8 @@ func TestGetNodeMetrics_WithMockStore(t *testing.T) {
 	mockStore := NewMockMetricsStore()
 	mockStore.SetMetric("kubelet_node_cpu_usage_seconds_total", "node:test-node", 2.5)
 	mockStore.SetMetric("kubelet_node_memory_working_set_bytes", "node:test-node", 1024*1024*1024) // 1GB
-	mockStore.SetMetric("kubelet_node_network_receive_bytes_total", "node:test-node", 1024*1024)    // 1MB
-	mockStore.SetMetric("kubelet_node_network_transmit_bytes_total", "node:test-node", 512*1024)    // 512KB
+	mockStore.SetMetric("kubelet_node_network_receive_bytes_total", "node:test-node", 1024*1024)   // 1MB
+	mockStore.SetMetric("kubelet_node_network_transmit_bytes_total", "node:test-node", 512*1024)   // 512KB
 	mockStore.SetMetric("kubelet_node_load1", "node:test-node", 1.5)
 	mockStore.SetMetric("kubelet_node_load5", "node:test-node", 1.2)
 	mockStore.SetMetric("kubelet_node_load15", "node:test-node", 0.9)

--- a/out.txt
+++ b/out.txt
@@ -1,0 +1,2827 @@
+Connected to: https://192.168.49.2:8443
+Using metrics source: Metrics Server
+
+ _    _
+| | _| |_ ___  _ __
+| |/ / __/ _ \| '_ \
+|   <| || (_) | |_) |
+|_|\_\\__\___/| .__/
+              |_|
+Version v0.0.0 (unknown)
+Loading cluster data...
+runtime: goroutine stack exceeds 1000000000-byte limit
+runtime: sp=0x404b91c3a0 stack=[0x404b91c000, 0x406b91c000]
+fatal error: stack overflow
+
+runtime stack:
+runtime.throw({0x251f479?, 0x200000008?})
+	/snap/go/10988/src/runtime/panic.go:1094 +0x34 fp=0xe1a88128c6d0 sp=0xe1a88128c6a0 pc=0xe7d1e4
+runtime.newstack()
+	/snap/go/10988/src/runtime/stack.go:1159 +0x44c fp=0xe1a88128c800 sp=0xe1a88128c6d0 pc=0xe62cdc
+runtime.morestack()
+	/snap/go/10988/src/runtime/asm_arm64.s:392 +0x70 fp=0xe1a88128c800 sp=0xe1a88128c800 pc=0xe83440
+
+goroutine 111 gp=0x4000513c00 m=8 mp=0x4000101008 [running]:
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:15 +0x288 fp=0x404b91c3a0 sp=0x404b91c3a0 pc=0x1fc62d8
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c400 sp=0x404b91c3a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91c4b0 sp=0x404b91c400 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c510 sp=0x404b91c4b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91c5c0 sp=0x404b91c510 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c620 sp=0x404b91c5c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91c6d0 sp=0x404b91c620 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c730 sp=0x404b91c6d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91c7e0 sp=0x404b91c730 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c840 sp=0x404b91c7e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91c8f0 sp=0x404b91c840 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91c950 sp=0x404b91c8f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91ca00 sp=0x404b91c950 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91ca60 sp=0x404b91ca00 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91cb10 sp=0x404b91ca60 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91cb70 sp=0x404b91cb10 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91cc20 sp=0x404b91cb70 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91cc80 sp=0x404b91cc20 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91cd30 sp=0x404b91cc80 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91cd90 sp=0x404b91cd30 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91ce40 sp=0x404b91cd90 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91cea0 sp=0x404b91ce40 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91cf50 sp=0x404b91cea0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91cfb0 sp=0x404b91cf50 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d060 sp=0x404b91cfb0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d0c0 sp=0x404b91d060 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d170 sp=0x404b91d0c0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d1d0 sp=0x404b91d170 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d280 sp=0x404b91d1d0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d2e0 sp=0x404b91d280 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d390 sp=0x404b91d2e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d3f0 sp=0x404b91d390 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d4a0 sp=0x404b91d3f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d500 sp=0x404b91d4a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d5b0 sp=0x404b91d500 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d610 sp=0x404b91d5b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d6c0 sp=0x404b91d610 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d720 sp=0x404b91d6c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d7d0 sp=0x404b91d720 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d830 sp=0x404b91d7d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d8e0 sp=0x404b91d830 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91d940 sp=0x404b91d8e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91d9f0 sp=0x404b91d940 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91da50 sp=0x404b91d9f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91db00 sp=0x404b91da50 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91db60 sp=0x404b91db00 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91dc10 sp=0x404b91db60 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91dc70 sp=0x404b91dc10 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x404b91dd20 sp=0x404b91dc70 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x404b91dd80 sp=0x404b91dd20 pc=0x1fe0e30
+...3947467 frames elided...
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c238?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a1e0 sp=0x406b91a180 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x4000712918?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c328?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a290 sp=0x406b91a1e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x213eae0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a2f0 sp=0x406b91a290 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026c488?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c438?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a3a0 sp=0x406b91a2f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c498?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a400 sp=0x406b91a3a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026c538?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x40007128f0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a4b0 sp=0x406b91a400 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c898?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a510 sp=0x406b91a4b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026c608?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x2?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a5c0 sp=0x406b91a510 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c6b8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a620 sp=0x406b91a5c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x213eae0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x2111160?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a6d0 sp=0x406b91a620 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x2?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a730 sp=0x406b91a6d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x4000712918?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026c878?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a7e0 sp=0x406b91a730 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x4000712918?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a840 sp=0x406b91a7e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x4000712918?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x40007128f0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91a8f0 sp=0x406b91a840 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x220ca3b?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91a950 sp=0x406b91a8f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x10?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91aa00 sp=0x406b91a950 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x19?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91aa60 sp=0x406b91aa00 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x236b620?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91ab10 sp=0x406b91aa60 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x23fe7c0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91ab70 sp=0x406b91ab10 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026cc98?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026cc68?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91ac20 sp=0x406b91ab70 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026ccd8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91ac80 sp=0x406b91ac20 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026cda8?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91ad30 sp=0x406b91ac80 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026cdd8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91ad90 sp=0x406b91ad30 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026d1a8?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x4000148060?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91ae40 sp=0x406b91ad90 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91aea0 sp=0x406b91ae40 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40005b0f98?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91af50 sp=0x406b91aea0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x236b620?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91afb0 sp=0x406b91af50 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x40005b10e8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b060 sp=0x406b91afb0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x40006ff4a0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b0c0 sp=0x406b91b060 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x4000712918?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x40003ba090?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b170 sp=0x406b91b0c0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b1d0 sp=0x406b91b170 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026d2c8?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x4000148040?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b280 sp=0x406b91b1d0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x2?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b2e0 sp=0x406b91b280 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x27c6d58?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b390 sp=0x406b91b2e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x27c73b0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b3f0 sp=0x406b91b390 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026d4b8?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x1000?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b4a0 sp=0x406b91b3f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x249c4d8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b500 sp=0x406b91b4a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x3?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x228ba40?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b5b0 sp=0x406b91b500 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b610 sp=0x406b91b5b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026d7a8?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026d7c8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b6c0 sp=0x406b91b610 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026d768?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b720 sp=0x406b91b6c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400026d818?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x24ab0a0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b7d0 sp=0x406b91b720 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x4000101008?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b830 sp=0x406b91b7d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x22?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b8e0 sp=0x406b91b830 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x400026d9e8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x406b91b940 sp=0x406b91b8e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x400067a400?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x406b91b9f0 sp=0x406b91b940 pc=0x1fc6088
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetPodModels(0x40003e6000, {0x27ddb30, 0x400048a9b0})
+	/home/vladimir/DEV/ktop/k8s/pods_controller.go:41 +0x1d4 fp=0x406b91bee0 sp=0x406b91b9f0 pc=0x1fc7aa4
+github.com/vladimirvivien/ktop/k8s.(*Controller).refreshPods(0x4000079f60?, {0x27ddb30, 0x400048a9b0}, 0x400022f0d0)
+	/home/vladimir/DEV/ktop/k8s/pods_controller.go:91 +0x28 fp=0x406b91bf20 sp=0x406b91bee0 pc=0x1fc8128
+github.com/vladimirvivien/ktop/k8s.(*Controller).installPodsHandler.func1()
+	/home/vladimir/DEV/ktop/k8s/pods_controller.go:74 +0x40 fp=0x406b91bfd0 sp=0x406b91bf20 pc=0x1fc7fc0
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x406b91bfd0 sp=0x406b91bfd0 pc=0xe857d4
+created by github.com/vladimirvivien/ktop/k8s.(*Controller).installPodsHandler in goroutine 46
+	/home/vladimir/DEV/ktop/k8s/pods_controller.go:73 +0x90
+
+goroutine 1 gp=0x40000021c0 m=nil [select]:
+runtime.gopark(0x40004cbc08?, 0x2?, 0xb?, 0x0?, 0x40004cbaa4?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005b7900 sp=0x40005b78e0 pc=0xe7da00
+runtime.selectgo(0x40005b7c08, 0x40004cbaa0, 0x400048a9b0?, 0x0, 0x233fc00?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005b7a40 sp=0x40005b7900 pc=0xe5c11c
+github.com/vladimirvivien/ktop/cmd.(*ktopCmdOptions).runKtop(0x4000496000, 0x4000477b88, {0x0?, 0x40002d2cd0?, 0xff01c0?})
+	/home/vladimir/DEV/ktop/cmd/ktop.go:225 +0xcd4 fp=0x40005b7cf0 sp=0x40005b7a40 pc=0x1febc94
+github.com/vladimirvivien/ktop/cmd.NewKtopCmd.func1(0x40001cad00?, {0x37367c0?, 0x4?, 0x2515023?})
+	/home/vladimir/DEV/ktop/cmd/ktop.go:74 +0x38 fp=0x40005b7d30 sp=0x40005b7cf0 pc=0x1feaf98
+github.com/spf13/cobra.(*Command).execute(0x4000477b88, {0x40000500d0, 0x0, 0x0})
+	/home/vladimir/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x548 fp=0x40005b7e10 sp=0x40005b7d30 pc=0xfef8e8
+github.com/spf13/cobra.(*Command).ExecuteC(0x4000477b88)
+	/home/vladimir/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x2e4 fp=0x40005b7ed0 sp=0x40005b7e10 pc=0xfefec4
+github.com/spf13/cobra.(*Command).Execute(0x400019a000?)
+	/home/vladimir/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902 +0x1c fp=0x40005b7ef0 sp=0x40005b7ed0 pc=0xfefb3c
+main.main()
+	/home/vladimir/DEV/ktop/main.go:33 +0x1a4 fp=0x40005b7f40 sp=0x40005b7ef0 pc=0x1febff4
+runtime.main()
+	/snap/go/10988/src/runtime/proc.go:285 +0x278 fp=0x40005b7fd0 sp=0x40005b7f40 pc=0xe48418
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005b7fd0 sp=0x40005b7fd0 pc=0xe857d4
+
+goroutine 2 gp=0x4000002c40 m=nil [force gc (idle)]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007af90 sp=0x400007af70 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+runtime.forcegchelper()
+	/snap/go/10988/src/runtime/proc.go:373 +0xb4 fp=0x400007afd0 sp=0x400007af90 pc=0xe48764
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007afd0 sp=0x400007afd0 pc=0xe857d4
+created by runtime.init.7 in goroutine 1
+	/snap/go/10988/src/runtime/proc.go:361 +0x24
+
+goroutine 3 gp=0x4000003180 m=nil [GC sweep wait]:
+runtime.gopark(0x1?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007b760 sp=0x400007b740 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+runtime.bgsweep(0x40000a4000)
+	/snap/go/10988/src/runtime/mgcsweep.go:323 +0x104 fp=0x400007b7b0 sp=0x400007b760 pc=0xe30d24
+runtime.gcenable.gowrap1()
+	/snap/go/10988/src/runtime/mgc.go:212 +0x28 fp=0x400007b7d0 sp=0x400007b7b0 pc=0xe24678
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007b7d0 sp=0x400007b7d0 pc=0xe857d4
+created by runtime.gcenable in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:212 +0x6c
+
+goroutine 4 gp=0x4000003340 m=nil [GC scavenge wait]:
+runtime.gopark(0x10000?, 0x27b23d0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007bf60 sp=0x400007bf40 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+runtime.(*scavengerState).park(0x370d820)
+	/snap/go/10988/src/runtime/mgcscavenge.go:425 +0x5c fp=0x400007bf90 sp=0x400007bf60 pc=0xe2e73c
+runtime.bgscavenge(0x40000a4000)
+	/snap/go/10988/src/runtime/mgcscavenge.go:658 +0xac fp=0x400007bfb0 sp=0x400007bf90 pc=0xe2ecdc
+runtime.gcenable.gowrap2()
+	/snap/go/10988/src/runtime/mgc.go:213 +0x28 fp=0x400007bfd0 sp=0x400007bfb0 pc=0xe24618
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007bfd0 sp=0x400007bfd0 pc=0xe857d4
+created by runtime.gcenable in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:213 +0xac
+
+goroutine 5 gp=0x4000003c00 m=nil [finalizer wait]:
+runtime.gopark(0x22c3ea0?, 0x1e?, 0xb8?, 0x1?, 0x1000000000000?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007a580 sp=0x400007a560 pc=0xe7da00
+runtime.runFinalizers()
+	/snap/go/10988/src/runtime/mfinal.go:210 +0x104 fp=0x400007a7d0 sp=0x400007a580 pc=0xe23664
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007a7d0 sp=0x400007a7d0 pc=0xe857d4
+created by runtime.createfing in goroutine 1
+	/snap/go/10988/src/runtime/mfinal.go:172 +0x78
+
+goroutine 6 gp=0x40001efdc0 m=nil [cleanup wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007c740 sp=0x400007c720 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+runtime.(*cleanupQueue).dequeue(0x370e3a0)
+	/snap/go/10988/src/runtime/mcleanup.go:439 +0x110 fp=0x400007c780 sp=0x400007c740 pc=0xe1ff50
+runtime.runCleanups()
+	/snap/go/10988/src/runtime/mcleanup.go:635 +0x40 fp=0x400007c7d0 sp=0x400007c780 pc=0xe20760
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007c7d0 sp=0x400007c7d0 pc=0xe857d4
+created by runtime.(*cleanupQueue).createGs in goroutine 1
+	/snap/go/10988/src/runtime/mcleanup.go:589 +0x108
+
+goroutine 7 gp=0x400047e1c0 m=nil [GC worker (idle)]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007cf10 sp=0x400007cef0 pc=0xe7da00
+runtime.gcBgMarkWorker(0x40000b2d90)
+	/snap/go/10988/src/runtime/mgc.go:1463 +0xe0 fp=0x400007cfb0 sp=0x400007cf10 pc=0xe26cf0
+runtime.gcBgMarkStartWorkers.gowrap1()
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x28 fp=0x400007cfd0 sp=0x400007cfb0 pc=0xe26bd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007cfd0 sp=0x400007cfd0 pc=0xe857d4
+created by runtime.gcBgMarkStartWorkers in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x140
+
+goroutine 8 gp=0x400047e380 m=nil [GC worker (idle)]:
+runtime.gopark(0x2332c623eb50d?, 0x1?, 0xc4?, 0x5?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400008df10 sp=0x400008def0 pc=0xe7da00
+runtime.gcBgMarkWorker(0x40000b2d90)
+	/snap/go/10988/src/runtime/mgc.go:1463 +0xe0 fp=0x400008dfb0 sp=0x400008df10 pc=0xe26cf0
+runtime.gcBgMarkStartWorkers.gowrap1()
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x28 fp=0x400008dfd0 sp=0x400008dfb0 pc=0xe26bd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400008dfd0 sp=0x400008dfd0 pc=0xe857d4
+created by runtime.gcBgMarkStartWorkers in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x140
+
+goroutine 9 gp=0x400047e540 m=nil [GC worker (idle)]:
+runtime.gopark(0x3738260?, 0x1?, 0xa6?, 0x61?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400068df10 sp=0x400068def0 pc=0xe7da00
+runtime.gcBgMarkWorker(0x40000b2d90)
+	/snap/go/10988/src/runtime/mgc.go:1463 +0xe0 fp=0x400068dfb0 sp=0x400068df10 pc=0xe26cf0
+runtime.gcBgMarkStartWorkers.gowrap1()
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x28 fp=0x400068dfd0 sp=0x400068dfb0 pc=0xe26bd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400068dfd0 sp=0x400068dfd0 pc=0xe857d4
+created by runtime.gcBgMarkStartWorkers in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x140
+
+goroutine 10 gp=0x400047e700 m=nil [GC worker (idle)]:
+runtime.gopark(0x2332c621e6b4d?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005adf10 sp=0x40005adef0 pc=0xe7da00
+runtime.gcBgMarkWorker(0x40000b2d90)
+	/snap/go/10988/src/runtime/mgc.go:1463 +0xe0 fp=0x40005adfb0 sp=0x40005adf10 pc=0xe26cf0
+runtime.gcBgMarkStartWorkers.gowrap1()
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x28 fp=0x40005adfd0 sp=0x40005adfb0 pc=0xe26bd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005adfd0 sp=0x40005adfd0 pc=0xe857d4
+created by runtime.gcBgMarkStartWorkers in goroutine 1
+	/snap/go/10988/src/runtime/mgc.go:1373 +0x140
+
+goroutine 11 gp=0x4000102380 m=nil [select]:
+runtime.gopark(0x400008ce58?, 0x4?, 0xb8?, 0xcc?, 0x400008cdf0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400008cc60 sp=0x400008cc40 pc=0xe7da00
+runtime.selectgo(0x400008ce58, 0x400008cde8, 0x400007d5d8?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400008cda0 sp=0x400008cc60 pc=0xe5c11c
+k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0x4000470960)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/util/workqueue/delaying_queue.go:276 +0x23c fp=0x400008cfb0 sp=0x400008cda0 pc=0x1b0a6bc
+k8s.io/client-go/util/workqueue.newDelayingQueue.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/util/workqueue/delaying_queue.go:113 +0x28 fp=0x400008cfd0 sp=0x400008cfb0 pc=0x1b09ec8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400008cfd0 sp=0x400008cfd0 pc=0xe857d4
+created by k8s.io/client-go/util/workqueue.newDelayingQueue in goroutine 1
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/util/workqueue/delaying_queue.go:113 +0x1b8
+
+goroutine 12 gp=0x4000102540 m=nil [chan receive]:
+runtime.gopark(0x10?, 0x1b16184?, 0x0?, 0x0?, 0xe1a884559970?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000076e30 sp=0x4000076e10 pc=0xe7da00
+runtime.chanrecv(0x40000b2bd0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000076eb0 sp=0x4000076e30 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x4000076ee0 sp=0x4000076eb0 pc=0xe130f4
+k8s.io/client-go/transport.(*dynamicClientCert).Run(0x4000452300, 0x40000b2bd0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:147 +0x22c fp=0x4000076fb0 sp=0x4000076ee0 pc=0x1b162dc
+k8s.io/client-go/transport.(*tlsTransportCache).get.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cache.go:116 +0x28 fp=0x4000076fd0 sp=0x4000076fb0 pc=0x1b156b8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000076fd0 sp=0x4000076fd0 pc=0xe857d4
+created by k8s.io/client-go/transport.(*tlsTransportCache).get in goroutine 1
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cache.go:116 +0x358
+
+goroutine 18 gp=0x400047ea80 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x400008fd28?, 0x1b0e2d4?, 0x70?, 0x62?, 0x23c7f40?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400008fc90 sp=0x400008fc70 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40004522d0, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400008fce0 sp=0x400008fc90 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40004522c0)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400008fd10 sp=0x400008fce0 pc=0xe9f124
+k8s.io/client-go/util/workqueue.(*Type).Get(0x4000470900)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/util/workqueue/queue.go:200 +0x7c fp=0x400008fd80 sp=0x400008fd10 pc=0x1b0bcec
+k8s.io/client-go/util/workqueue.(*delayingType).Get(0x27b9f00?)
+	<autogenerated>:1 +0x2c fp=0x400008fda0 sp=0x400008fd80 pc=0x1b0e40c
+k8s.io/client-go/util/workqueue.(*rateLimitingType).Get(0x4000452300?)
+	<autogenerated>:1 +0x2c fp=0x400008fdc0 sp=0x400008fda0 pc=0x1b0f47c
+k8s.io/client-go/transport.(*dynamicClientCert).processNextWorkItem(0x4000452300)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:156 +0x38 fp=0x400008fe90 sp=0x400008fdc0 pc=0x1b165f8
+k8s.io/client-go/transport.(*dynamicClientCert).runWorker(...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:151
+k8s.io/client-go/transport.(*dynamicClientCert).runWorker-fm()
+	<autogenerated>:1 +0x34 fp=0x400008feb0 sp=0x400008fe90 pc=0x1b1cbb4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400008fed0 sp=0x400008feb0 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000050020, {0x27c30e0, 0x400002c000}, 0x1, 0x40000b2bd0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400008ff50 sp=0x400008fed0 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000050020, 0x3b9aca00, 0x0, 0x1, 0x40000b2bd0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x400008ff90 sp=0x400008ff50 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/transport.(*dynamicClientCert).Run.gowrap4()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:140 +0x38 fp=0x400008ffd0 sp=0x400008ff90 pc=0x1b16438
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400008ffd0 sp=0x400008ffd0 pc=0xe857d4
+created by k8s.io/client-go/transport.(*dynamicClientCert).Run in goroutine 12
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:140 +0x188
+
+goroutine 19 gp=0x400047ec40 m=nil [select]:
+runtime.gopark(0x4000136eb0?, 0x2?, 0x48?, 0x6d?, 0x4000136e94?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000136d10 sp=0x4000136cf0 pc=0xe7da00
+runtime.selectgo(0x4000136eb0, 0x4000136e90, 0x4000136e98?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000136e50 sp=0x4000136d10 pc=0xe5c11c
+k8s.io/apimachinery/pkg/util/wait.waitForWithContext({0x27de348, 0x40000b2bd0}, 0x4000136f40, 0x4000136f88)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:205 +0xac fp=0x4000136ee0 sp=0x4000136e50 pc=0x1b06c2c
+k8s.io/apimachinery/pkg/util/wait.poll({0x27de348, 0x40000b2bd0}, 0x0?, 0x4000136f40, 0x4000136f88)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/poll.go:260 +0x8c fp=0x4000136f10 sp=0x4000136ee0 pc=0x1b0626c
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext({0x27de348?, 0x40000b2bd0?}, 0x0?, 0x0?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/poll.go:200 +0x40 fp=0x4000136f60 sp=0x4000136f10 pc=0x1b05d70
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil(0x0?, 0x0?, 0x0?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/poll.go:187 +0x3c fp=0x4000136fa0 sp=0x4000136f60 pc=0x1b05cbc
+k8s.io/client-go/transport.(*dynamicClientCert).Run.gowrap5()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:142 +0x2c fp=0x4000136fd0 sp=0x4000136fa0 pc=0x1b1636c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000136fd0 sp=0x4000136fd0 pc=0xe857d4
+created by k8s.io/client-go/transport.(*dynamicClientCert).Run in goroutine 12
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/transport/cert_rotation.go:142 +0x220
+
+goroutine 20 gp=0x400047ee00 m=nil [select]:
+runtime.gopark(0x400012af50?, 0x3?, 0xd8?, 0xad?, 0x400012af12?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012ad90 sp=0x400012ad70 pc=0xe7da00
+runtime.selectgo(0x400012af50, 0x400012af0c, 0x27de348?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400012aed0 sp=0x400012ad90 pc=0xe5c11c
+k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext.poller.func1.1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/poll.go:297 +0x13c fp=0x400012afd0 sp=0x400012aed0 pc=0x1b05fbc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012afd0 sp=0x400012afd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext.poller.func1 in goroutine 19
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/poll.go:280 +0xb8
+
+goroutine 83 gp=0x4000102700 m=nil [chan receive]:
+runtime.gopark(0x400012a628?, 0xe2dc00?, 0x98?, 0xa6?, 0xe13aac?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012a600 sp=0x400012a5e0 pc=0xe7da00
+runtime.chanrecv(0x40000220e0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400012a680 sp=0x400012a600 pc=0xe13558
+runtime.chanrecv1(0x40003c9c20?, 0x260c450?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400012a6b0 sp=0x400012a680 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9c20, 0x40000220e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400012a760 sp=0x400012a6b0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400012a780 sp=0x400012a760 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400012a7a0 sp=0x400012a780 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400012a7d0 sp=0x400012a7a0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012a7d0 sp=0x400012a7d0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 57
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 139 gp=0x40001028c0 m=nil [select]:
+runtime.gopark(0x400051af40?, 0x3?, 0x68?, 0xae?, 0x400051af22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400051ad70 sp=0x400051ad50 pc=0xe7da00
+runtime.selectgo(0x400051af40, 0x400051af1c, 0x400051af40?, 0x0, 0x40003f63c0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400051aeb0 sp=0x400051ad70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x4000584780, 0x40000b3180, 0x4000139260, 0x40002bd500)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x400051afa0 sp=0x400051aeb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x400051afd0 sp=0x400051afa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400051afd0 sp=0x400051afd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 124
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 46 gp=0x4000102a80 m=nil [select]:
+runtime.gopark(0x400059fed8?, 0x2?, 0xa8?, 0xa2?, 0x400059fe3c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400059fcb0 sp=0x400059fc90 pc=0xe7da00
+runtime.selectgo(0x400059fed8, 0x400059fe38, 0x0?, 0x0, 0x400043f170?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400059fdf0 sp=0x400059fcb0 pc=0xe5c11c
+github.com/rivo/tview.(*Application).Run(0x40001f1180)
+	/home/vladimir/go/pkg/mod/github.com/rivo/tview@v0.0.0-20211202162923-2a6de950f73b/application.go:302 +0x1fc fp=0x400059ff60 sp=0x400059fdf0 pc=0x106747c
+github.com/vladimirvivien/ktop/application.(*Application).Run(0x40004d7b90, {0x27ddb30?, 0x400048a9b0?})
+	/home/vladimir/DEV/ktop/application/app_ctrl.go:174 +0x78 fp=0x400059ff90 sp=0x400059ff60 pc=0x1fcb2e8
+github.com/vladimirvivien/ktop/cmd.(*ktopCmdOptions).runKtop.func1()
+	/home/vladimir/DEV/ktop/cmd/ktop.go:222 +0x28 fp=0x400059ffd0 sp=0x400059ff90 pc=0x1febdc8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400059ffd0 sp=0x400059ffd0 pc=0xe857d4
+created by github.com/vladimirvivien/ktop/cmd.(*ktopCmdOptions).runKtop in goroutine 1
+	/home/vladimir/DEV/ktop/cmd/ktop.go:221 +0xc88
+
+goroutine 47 gp=0x4000102c40 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x400016ea18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400016e9d0 sp=0x400016e9b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b22e8, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400016ea20 sp=0x400016e9d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b22d8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400016ea50 sp=0x400016ea20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b22c0, 0x40002a0910)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x400016ebb0 sp=0x400016ea50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f8c80)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x400016ebf0 sp=0x400016ebb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x400016ec10 sp=0x400016ebf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400016ec30 sp=0x400016ec10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400016eda8, {0x27c30e0, 0x40002cc840}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400016ecb0 sp=0x400016ec30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x400016eda8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x400016ecf0 sp=0x400016ecb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f8c80, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x400016ee00 sp=0x400016ecf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181a20, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x400016ef90 sp=0x400016ee00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x400016efd0 sp=0x400016ef90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400016efd0 sp=0x400016efd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 37 gp=0x4000102e00 m=nil [IO wait]:
+runtime.gopark(0x40003596e8?, 0x1ffa5ac?, 0x5?, 0xc0?, 0x2c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000359620 sp=0x4000359600 pc=0xe7da00
+runtime.netpollblock(0x0?, 0xffffffff?, 0xff?)
+	/snap/go/10988/src/runtime/netpoll.go:575 +0x150 fp=0x4000359660 sp=0x4000359620 pc=0xe40d00
+internal/poll.runtime_pollWait(0xe1a884556600, 0x72)
+	/snap/go/10988/src/runtime/netpoll.go:351 +0xa0 fp=0x4000359690 sp=0x4000359660 pc=0xe7c480
+internal/poll.(*pollDesc).wait(0x40003edc00?, 0x40006bc000?, 0x0)
+	/snap/go/10988/src/internal/poll/fd_poll_runtime.go:84 +0x28 fp=0x40003596c0 sp=0x4000359690 pc=0xefed98
+internal/poll.(*pollDesc).waitRead(...)
+	/snap/go/10988/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0x40003edc00, {0x40006bc000, 0xa000, 0xa000})
+	/snap/go/10988/src/internal/poll/fd_unix.go:165 +0x1e0 fp=0x4000359760 sp=0x40003596c0 pc=0xf000f0
+net.(*netFD).Read(0x40003edc00, {0x40006bc000?, 0x40003597e8?, 0xe2dc00?})
+	/snap/go/10988/src/net/fd_posix.go:68 +0x28 fp=0x40003597b0 sp=0x4000359760 pc=0xf76768
+net.(*conn).Read(0x4000124430, {0x40006bc000?, 0x4000359878?, 0xe7acec?})
+	/snap/go/10988/src/net/net.go:196 +0x34 fp=0x4000359800 sp=0x40003597b0 pc=0xf86414
+k8s.io/client-go/util/connrotation.(*closableConn).Read(0x4000359878?, {0x40006bc000?, 0x3003598a8?, 0xe1a882ce9910?})
+	<autogenerated>:1 +0x30 fp=0x4000359830 sp=0x4000359800 pc=0x1b08870
+crypto/tls.(*atLeastReader).Read(0x400065baa0, {0x40006bc000?, 0x40003598d8?, 0x118b7f4?})
+	/snap/go/10988/src/crypto/tls/conn.go:816 +0x38 fp=0x4000359880 sp=0x4000359830 pc=0x118b698
+bytes.(*Buffer).ReadFrom(0x40003e4628, {0x27c2f80, 0x400065baa0})
+	/snap/go/10988/src/bytes/buffer.go:217 +0x90 fp=0x40003598e0 sp=0x4000359880 pc=0xf3ab00
+crypto/tls.(*Conn).readFromUntil(0x40003e4388, {0xe1a881333a00, 0x400022c108}, 0x4000359980?)
+	/snap/go/10988/src/crypto/tls/conn.go:838 +0xcc fp=0x4000359920 sp=0x40003598e0 pc=0x118b85c
+crypto/tls.(*Conn).readRecordOrCCS(0x40003e4388, 0x0)
+	/snap/go/10988/src/crypto/tls/conn.go:627 +0x340 fp=0x4000359ba0 sp=0x4000359920 pc=0x1189180
+crypto/tls.(*Conn).readRecord(...)
+	/snap/go/10988/src/crypto/tls/conn.go:589
+crypto/tls.(*Conn).Read(0x40003e4388, {0x40003d6000, 0x1000, 0x4?})
+	/snap/go/10988/src/crypto/tls/conn.go:1392 +0x14c fp=0x4000359c10 sp=0x4000359ba0 pc=0x118ec7c
+bufio.(*Reader).Read(0x4000263980, {0x40001f10e0, 0x9, 0x3?})
+	/snap/go/10988/src/bufio/bufio.go:245 +0x188 fp=0x4000359c50 sp=0x4000359c10 pc=0xf9de88
+io.ReadAtLeast({0x27c01a0, 0x4000263980}, {0x40001f10e0, 0x9, 0x9}, 0x9)
+	/snap/go/10988/src/io/io.go:335 +0x98 fp=0x4000359ca0 sp=0x4000359c50 pc=0xed2768
+io.ReadFull(...)
+	/snap/go/10988/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0x40001f10e0, 0x9, 0x25153af?}, {0x27c01a0?, 0x4000263980?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/frame.go:242 +0x58 fp=0x4000359cf0 sp=0x4000359ca0 pc=0x13186f8
+golang.org/x/net/http2.(*Framer).ReadFrame(0x40001f10a0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/frame.go:506 +0x74 fp=0x4000359df0 sp=0x4000359cf0 pc=0x1319224
+golang.org/x/net/http2.(*clientConnReadLoop).run(0x4000359f98)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2258 +0xcc fp=0x4000359f40 sp=0x4000359df0 pc=0x132abec
+golang.org/x/net/http2.(*ClientConn).readLoop(0x4000103180)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2127 +0x6c fp=0x4000359fb0 sp=0x4000359f40 pc=0x1329f4c
+golang.org/x/net/http2.(*Transport).newClientConn.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:912 +0x28 fp=0x4000359fd0 sp=0x4000359fb0 pc=0x1323d28
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000359fd0 sp=0x4000359fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*Transport).newClientConn in goroutine 36
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:912 +0xae0
+
+goroutine 48 gp=0x4000103340 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000171a18?, 0xe9f118?, 0xc8?, 0x1a?, 0xe9fc4c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001719d0 sp=0x40001719b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b2398, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000171a20 sp=0x40001719d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b2388)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000171a50 sp=0x4000171a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b2370, 0x40002a0bb0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000171bb0 sp=0x4000171a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f8dc0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000171bf0 sp=0x4000171bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000171c10 sp=0x4000171bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000171c30 sp=0x4000171c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000171da8, {0x27c30e0, 0x40002cca80}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000171cb0 sp=0x4000171c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000171da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000171cf0 sp=0x4000171cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f8dc0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000171e00 sp=0x4000171cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181b80, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000171f90 sp=0x4000171e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000171fd0 sp=0x4000171f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000171fd0 sp=0x4000171fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 49 gp=0x4000103500 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000172a18?, 0xe9f118?, 0xc8?, 0x2a?, 0xe9fc4c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001729d0 sp=0x40001729b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x400013c0d8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000172a20 sp=0x40001729d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x400013c0c8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000172a50 sp=0x4000172a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x400013c0b0, 0x40000506b0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000172bb0 sp=0x4000172a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x400042e1e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000172bf0 sp=0x4000172bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000172c10 sp=0x4000172bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000172c30 sp=0x4000172c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000172da8, {0x27c30e0, 0x400013a390}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000172cb0 sp=0x4000172c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000172da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000172cf0 sp=0x4000172cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x400042e1e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000172e00 sp=0x4000172cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000506000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000172f90 sp=0x4000172e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000172fd0 sp=0x4000172f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000172fd0 sp=0x4000172fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 50 gp=0x40001036c0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000131a18?, 0xe9f118?, 0x4b?, 0x0?, 0xe7?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001319d0 sp=0x40001319b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000506238, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000131a20 sp=0x40001319d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000506228)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000131a50 sp=0x4000131a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x4000506210, 0x400022f510)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000131bb0 sp=0x4000131a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003b9900)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000131bf0 sp=0x4000131bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000131c10 sp=0x4000131bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000131c30 sp=0x4000131c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000131da8, {0x27c30e0, 0x4000514240}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000131cb0 sp=0x4000131c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000131da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000131cf0 sp=0x4000131cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003b9900, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000131e00 sp=0x4000131cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181ad0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000131f90 sp=0x4000131e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000131fd0 sp=0x4000131f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000131fd0 sp=0x4000131fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 51 gp=0x4000103880 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000134a18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001349d0 sp=0x40001349b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b2028, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000134a20 sp=0x40001349d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b2018)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000134a50 sp=0x4000134a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b2000, 0x40002a0030)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000134bb0 sp=0x4000134a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f8140)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000134bf0 sp=0x4000134bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000134c10 sp=0x4000134bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000134c30 sp=0x4000134c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000134da8, {0x27c30e0, 0x40002cc030}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000134cb0 sp=0x4000134c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000134da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000134cf0 sp=0x4000134cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f8140, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000134e00 sp=0x4000134cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181c30, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000134f90 sp=0x4000134e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000134fd0 sp=0x4000134f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000134fd0 sp=0x4000134fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 52 gp=0x4000103a40 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000350a18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40003509d0 sp=0x40003509b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000506188, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000350a20 sp=0x40003509d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000506178)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000350a50 sp=0x4000350a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x4000506160, 0x400022f270)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000350bb0 sp=0x4000350a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003b97c0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000350bf0 sp=0x4000350bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000350c10 sp=0x4000350bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000350c30 sp=0x4000350c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000350da8, {0x27c30e0, 0x4000514000}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000350cb0 sp=0x4000350c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000350da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000350cf0 sp=0x4000350cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003b97c0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000350e00 sp=0x4000350cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181ce0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000350f90 sp=0x4000350e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000350fd0 sp=0x4000350f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000350fd0 sp=0x4000350fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 53 gp=0x4000103c00 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x400034ea18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400034e9d0 sp=0x400034e9b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b2188, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400034ea20 sp=0x400034e9d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b2178)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400034ea50 sp=0x400034ea20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b2160, 0x40002a03d0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x400034ebb0 sp=0x400034ea50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f8320)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x400034ebf0 sp=0x400034ebb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x400034ec10 sp=0x400034ebf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400034ec30 sp=0x400034ec10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400034eda8, {0x27c30e0, 0x40002cc3c0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400034ecb0 sp=0x400034ec30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x400034eda8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x400034ecf0 sp=0x400034ecb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f8320, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x400034ee00 sp=0x400034ecf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181d90, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x400034ef90 sp=0x400034ee00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x400034efd0 sp=0x400034ef90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400034efd0 sp=0x400034efd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 54 gp=0x4000103dc0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000519a18?, 0xe9f118?, 0xc8?, 0x9a?, 0xe9fc4c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005199d0 sp=0x40005199b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b2238, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000519a20 sp=0x40005199d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b2228)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000519a50 sp=0x4000519a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b2210, 0x40002a0670)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000519bb0 sp=0x4000519a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f8be0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000519bf0 sp=0x4000519bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000519c10 sp=0x4000519bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000519c30 sp=0x4000519c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000519da8, {0x27c30e0, 0x40002cc600}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000519cb0 sp=0x4000519c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000519da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000519cf0 sp=0x4000519cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f8be0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000519e00 sp=0x4000519cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181e40, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000519f90 sp=0x4000519e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000519fd0 sp=0x4000519f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000519fd0 sp=0x4000519fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 55 gp=0x40002c7340 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x400034ca18?, 0xe9f118?, 0x4b?, 0x0?, 0xe7?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400034c9d0 sp=0x400034c9b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40002b20d8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400034ca20 sp=0x400034c9d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40002b20c8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400034ca50 sp=0x400034ca20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x40002b20b0, 0x40002a02d0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x400034cbb0 sp=0x400034ca50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x40003f81e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x400034cbf0 sp=0x400034cbb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x400034cc10 sp=0x400034cbf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400034cc30 sp=0x400034cc10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400034cda8, {0x27c30e0, 0x40002cc270}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400034ccb0 sp=0x400034cc30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x400034cda8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x400034ccf0 sp=0x400034ccb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x40003f81e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x400034ce00 sp=0x400034ccf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x40005060b0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x400034cf90 sp=0x400034ce00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x400034cfd0 sp=0x400034cf90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400034cfd0 sp=0x400034cfd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 56 gp=0x40002c7500 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000137a18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001379d0 sp=0x40001379b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x400013c028, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000137a20 sp=0x40001379d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x400013c018)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000137a50 sp=0x4000137a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x400013c000, 0x40000502b0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000137bb0 sp=0x4000137a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x400042e140)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000137bf0 sp=0x4000137bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000137c10 sp=0x4000137bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000137c30 sp=0x4000137c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000137da8, {0x27c30e0, 0x400013a060}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000137cb0 sp=0x4000137c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000137da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000137cf0 sp=0x4000137cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x400042e140, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000137e00 sp=0x4000137cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x40001818c0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000137f90 sp=0x4000137e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000137fd0 sp=0x4000137f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000137fd0 sp=0x4000137fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 57 gp=0x40002c76c0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x4000132a18?, 0xe9f118?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40001329d0 sp=0x40001329b0 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x400002e028, 0x1)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000132a20 sp=0x40001329d0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x400002e018)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000132a50 sp=0x4000132a20 pc=0xe9f124
+k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0x400002e000, 0x4000494120)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/delta_fifo.go:575 +0x1b8 fp=0x4000132bb0 sp=0x4000132a50 pc=0x1f43748
+k8s.io/client-go/tools/cache.(*controller).processLoop(0x400046a000)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:192 +0x38 fp=0x4000132bf0 sp=0x4000132bb0 pc=0x1f414b8
+k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
+	<autogenerated>:1 +0x28 fp=0x4000132c10 sp=0x4000132bf0 pc=0x1f55188
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000132c30 sp=0x4000132c10 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000132da8, {0x27c30e0, 0x400002c060}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000132cb0 sp=0x4000132c30 pc=0x1b047b0
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x4000132da8, 0x3b9aca00, 0x0, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:204 +0x7c fp=0x4000132cf0 sp=0x4000132cb0 pc=0x1b046dc
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:161
+k8s.io/client-go/tools/cache.(*controller).Run(0x400046a000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:163 +0x288 fp=0x4000132e00 sp=0x4000132cf0 pc=0x1f41138
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x4000181970, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:503 +0x480 fp=0x4000132f90 sp=0x4000132e00 pc=0x1f4c030
+k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:150 +0x54 fp=0x4000132fd0 sp=0x4000132f90 pc=0x1fb4654
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000132fd0 sp=0x4000132fd0 pc=0xe857d4
+created by k8s.io/client-go/informers.(*sharedInformerFactory).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/informers/factory.go:148 +0x1b4
+
+goroutine 122 gp=0x40002c7a40 m=nil [chan receive]:
+runtime.gopark(0x400050ee28?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050ee00 sp=0x400050ede0 pc=0xe7da00
+runtime.chanrecv(0x40005808c0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050ee80 sp=0x400050ee00 pc=0xe13558
+runtime.chanrecv1(0x40003c9c70?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050eeb0 sp=0x400050ee80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9c70, 0x40005808c0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400050ef60 sp=0x400050eeb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x4000286dc0?)
+	<autogenerated>:1 +0x30 fp=0x400050ef80 sp=0x400050ef60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400050efa0 sp=0x400050ef80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400050efd0 sp=0x400050efa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050efd0 sp=0x400050efd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 47
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 60 gp=0x4000512000 m=nil [chan receive]:
+runtime.gopark(0x400050f628?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050f600 sp=0x400050f5e0 pc=0xe7da00
+runtime.chanrecv(0x40005080e0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050f680 sp=0x400050f600 pc=0xe13558
+runtime.chanrecv1(0x40003c9db0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050f6b0 sp=0x400050f680 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9db0, 0x40005080e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400050f760 sp=0x400050f6b0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400050f780 sp=0x400050f760 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400050f7a0 sp=0x400050f780 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400050f7d0 sp=0x400050f7a0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050f7d0 sp=0x400050f7d0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 52
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 61 gp=0x40005121c0 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050fef0 sp=0x400050fed0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050ff70 sp=0x400050fef0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050ffa0 sp=0x400050ff70 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400050ffd0 sp=0x400050ffa0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050ffd0 sp=0x400050ffd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 52
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 67 gp=0x4000582000 m=nil [chan receive]:
+runtime.gopark(0x4000078628?, 0x4000102e00?, 0x38?, 0x86?, 0xe12934?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000078600 sp=0x40000785e0 pc=0xe7da00
+runtime.chanrecv(0x4000580000, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000078680 sp=0x4000078600 pc=0xe13558
+runtime.chanrecv1(0x40003c9d60?, 0x4000102e00?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x40000786b0 sp=0x4000078680 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9d60, 0x4000580000)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x4000078760 sp=0x40000786b0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x132a0b0?)
+	<autogenerated>:1 +0x30 fp=0x4000078780 sp=0x4000078760 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x40000787a0 sp=0x4000078780 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x40000787d0 sp=0x40000787a0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40000787d0 sp=0x40000787d0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 51
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 68 gp=0x40005821c0 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40000776f0 sp=0x40000776d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000077770 sp=0x40000776f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x40000777a0 sp=0x4000077770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x40000777d0 sp=0x40000777a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40000777d0 sp=0x40000777d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 51
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 62 gp=0x4000512380 m=nil [select]:
+runtime.gopark(0x4000357ac8?, 0x3?, 0x98?, 0x76?, 0x4000357822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000357670 sp=0x4000357650 pc=0xe7da00
+runtime.selectgo(0x4000357ac8, 0x400035781c, 0x27dda18?, 0x0, 0x400022aec0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40003577b0 sp=0x4000357670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x40002c15c0}, {0xe1a882ce2108, 0x4000506160}, {0x27f5390, 0x24e1040}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000357b30 sp=0x40003577b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40003e6690, {0x0?, 0x0?}, 0x40000b3180, 0x40002bc1c0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000357d10 sp=0x4000357b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40003e6690, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000357df0 sp=0x4000357d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000357e20 sp=0x4000357df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000357e40 sp=0x4000357e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000357f40, {0x27c3100, 0x40003ea190}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000357ec0 sp=0x4000357e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40003e6690, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000357f60 sp=0x4000357ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000357f80 sp=0x4000357f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000357fa0 sp=0x4000357f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000357fd0 sp=0x4000357fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000357fd0 sp=0x4000357fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 52
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 69 gp=0x4000582380 m=nil [select]:
+runtime.gopark(0x4000353ac8?, 0x3?, 0x98?, 0x36?, 0x4000353822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000353670 sp=0x4000353650 pc=0xe7da00
+runtime.selectgo(0x4000353ac8, 0x400035381c, 0x27dda18?, 0x0, 0x40001227e0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40003537b0 sp=0x4000353670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x40000a7ec0}, {0xe1a882ce2108, 0x40002b2000}, {0x27f5390, 0x24e13e0}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000353b30 sp=0x40003537b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x4000584000, {0x0?, 0x0?}, 0x40000b3180, 0x400019a4d0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000353d10 sp=0x4000353b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000584000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000353df0 sp=0x4000353d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000353e20 sp=0x4000353df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000353e40 sp=0x4000353e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000353f40, {0x27c3100, 0x40003f6000}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000353ec0 sp=0x4000353e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000584000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000353f60 sp=0x4000353ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000353f80 sp=0x4000353f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000353fa0 sp=0x4000353f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000353fd0 sp=0x4000353fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000353fd0 sp=0x4000353fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 51
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 132 gp=0x4000512540 m=nil [select]:
+runtime.gopark(0x400016cf40?, 0x3?, 0xa8?, 0xcd?, 0x400016cf22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400016cd70 sp=0x400016cd50 pc=0xe7da00
+runtime.selectgo(0x400016cf40, 0x400016cf1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400016ceb0 sp=0x400016cd70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40003e6690, 0x40000b3180, 0x40001387e0, 0x40002bc1c0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x400016cfa0 sp=0x400016ceb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x400016cfd0 sp=0x400016cfa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400016cfd0 sp=0x400016cfd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 62
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 103 gp=0x4000582540 m=nil [select]:
+runtime.gopark(0x40005abf40?, 0x3?, 0xa8?, 0xbd?, 0x40005abf22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005abd70 sp=0x40005abd50 pc=0xe7da00
+runtime.selectgo(0x40005abf40, 0x40005abf1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005abeb0 sp=0x40005abd70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x4000584000, 0x40000b3180, 0x4000580c40, 0x400019a4d0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x40005abfa0 sp=0x40005abeb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x40005abfd0 sp=0x40005abfa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005abfd0 sp=0x40005abfd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 69
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 92 gp=0x400047efc0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40006e1ab0 sp=0x40006e1a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000596948, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x40006e1b00 sp=0x40006e1ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000596938)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x40006e1b30 sp=0x40006e1b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000596930, {0x4000228400, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x40006e1ba0 sp=0x40006e1b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x40006e1c98?}, {0x4000228400?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x40006e1c30 sp=0x40006e1ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x40004663c0)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x40006e1c80 sp=0x40006e1c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x40004663c0)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x40006e1cd0 sp=0x40006e1c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x40004663c0, {0x2289cc0, 0x4000011770})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x40006e1d00 sp=0x40006e1cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40002cdcb0, {0x4000700800, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x40006e1d50 sp=0x40006e1d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x400040a6e0, 0x0, {0x27c7338, 0x40000a7d80})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x40006e1e00 sp=0x40006e1d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000122780)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x40006e1e60 sp=0x40006e1e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x40000a7d40)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x40006e1fb0 sp=0x40006e1e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x40006e1fd0 sp=0x40006e1fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40006e1fd0 sp=0x40006e1fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 130
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 22 gp=0x400047f180 m=nil [chan receive]:
+runtime.gopark(0x400012be28?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012be00 sp=0x400012bde0 pc=0xe7da00
+runtime.chanrecv(0x40001380e0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400012be80 sp=0x400012be00 pc=0xe13558
+runtime.chanrecv1(0x40003c9b30?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400012beb0 sp=0x400012be80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9b30, 0x40001380e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400012bf60 sp=0x400012beb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400012bf80 sp=0x400012bf60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400012bfa0 sp=0x400012bf80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400012bfd0 sp=0x400012bfa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012bfd0 sp=0x400012bfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 56
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 23 gp=0x400047f340 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012c6f0 sp=0x400012c6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400012c770 sp=0x400012c6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400012c7a0 sp=0x400012c770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400012c7d0 sp=0x400012c7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012c7d0 sp=0x400012c7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 56
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 84 gp=0x40001ef6c0 m=nil [chan receive]:
+runtime.gopark(0x400007d720?, 0x260abe8?, 0xa8?, 0xd7?, 0xe26bd8?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400007d6f0 sp=0x400007d6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400007d770 sp=0x400007d6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0xe857d4?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400007d7a0 sp=0x400007d770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400007d7d0 sp=0x400007d7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400007d7d0 sp=0x400007d7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 57
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 24 gp=0x400047f500 m=nil [select]:
+runtime.gopark(0x4000609ac8?, 0x3?, 0xb8?, 0x96?, 0x4000609822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000609670 sp=0x4000609650 pc=0xe7da00
+runtime.selectgo(0x4000609ac8, 0x400060981c, 0x27c9470?, 0x0, 0x27dda18?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40006097b0 sp=0x4000609670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x400003d2c0}, {0xe1a882ce2108, 0x400013c000}, {0x27f5390, 0x24e4de0}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000609b30 sp=0x40006097b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x4000140000, {0x0?, 0x0?}, 0x40000b3180, 0x400029c930)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000609d10 sp=0x4000609b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000140000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000609df0 sp=0x4000609d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000609e20 sp=0x4000609df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000609e40 sp=0x4000609e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000609f40, {0x27c3100, 0x40001d04b0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000609ec0 sp=0x4000609e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000140000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000609f60 sp=0x4000609ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000609f80 sp=0x4000609f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000609fa0 sp=0x4000609f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000609fd0 sp=0x4000609fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000609fd0 sp=0x4000609fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 56
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 85 gp=0x40001ef880 m=nil [select]:
+runtime.gopark(0x400051fac8?, 0x3?, 0xb8?, 0xf6?, 0x400051f822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400051f670 sp=0x400051f650 pc=0xe7da00
+runtime.selectgo(0x400051fac8, 0x400051f81c, 0x27c9470?, 0x0, 0x27dda18?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400051f7b0 sp=0x400051f670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x4000453640}, {0xe1a882ce2108, 0x400002e000}, {0x27f5390, 0x24e5180}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x400051fb30 sp=0x400051f7b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x4000034000, {0x0?, 0x0?}, 0x40000b3180, 0x400029caf0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x400051fd10 sp=0x400051fb30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000034000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x400051fdf0 sp=0x400051fd10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x400051fe20 sp=0x400051fdf0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400051fe40 sp=0x400051fe20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400051ff40, {0x27c3100, 0x400040a000}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400051fec0 sp=0x400051fe40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000034000, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x400051ff60 sp=0x400051fec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400051ff80 sp=0x400051ff60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400051ffa0 sp=0x400051ff80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400051ffd0 sp=0x400051ffa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400051ffd0 sp=0x400051ffd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 57
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 135 gp=0x4000512700 m=nil [select]:
+runtime.gopark(0x4000130ee8?, 0x6?, 0x8?, 0xc?, 0x4000130d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000130bd0 sp=0x4000130bb0 pc=0xe7da00
+runtime.selectgo(0x4000130ee8, 0x4000130d78, 0x4000000029?, 0x0, 0x8?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000130d10 sp=0x4000130bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000596900, 0x400061f2c0, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000130f70 sp=0x4000130d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000596900, 0x40004942a0?, 0x40004942b0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000130fa0 sp=0x4000130f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000130fd0 sp=0x4000130fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000130fd0 sp=0x4000130fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 130
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 146 gp=0x400047f6c0 m=nil [select]:
+runtime.gopark(0x40006e5f40?, 0x3?, 0xa8?, 0x5d?, 0x40006e5f22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40006e5d70 sp=0x40006e5d50 pc=0xe7da00
+runtime.selectgo(0x40006e5f40, 0x40006e5f1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40006e5eb0 sp=0x40006e5d70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x4000140000, 0x40000b3180, 0x4000022070, 0x400029c930)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x40006e5fa0 sp=0x40006e5eb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x40006e5fd0 sp=0x40006e5fa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40006e5fd0 sp=0x40006e5fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 24
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 91 gp=0x4000582700 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400034fab0 sp=0x400034fa90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40005001c8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400034fb00 sp=0x400034fab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40005001b8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400034fb30 sp=0x400034fb00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x40005001b0, {0x4000228200, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x400034fba0 sp=0x400034fb30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x400034fc98?}, {0x4000228200?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x400034fc30 sp=0x400034fba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000466280)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x400034fc80 sp=0x400034fc30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000466280)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x400034fcd0 sp=0x400034fc80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000466280, {0x2289cc0, 0x4000011710})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x400034fd00 sp=0x400034fcd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40002cdc20, {0x4000700400, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x400034fd50 sp=0x400034fd00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x400040a690, 0x0, {0x27c7338, 0x40000a7cc0})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x400034fe00 sp=0x400034fd50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000122720)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x400034fe60 sp=0x400034fe00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x40000a7c80)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x400034ffb0 sp=0x400034fe60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x400034ffd0 sp=0x400034ffb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400034ffd0 sp=0x400034ffd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 80
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 98 gp=0x40005128c0 m=nil [chan receive]:
+runtime.gopark(0x4000127628?, 0x0?, 0x1?, 0x0?, 0x1b047b0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000127600 sp=0x40001275e0 pc=0xe7da00
+runtime.chanrecv(0x4000508380, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000127680 sp=0x4000127600 pc=0xe13558
+runtime.chanrecv1(0x40003c9cc0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x40001276b0 sp=0x4000127680 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9cc0, 0x4000508380)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x4000127760 sp=0x40001276b0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000127780 sp=0x4000127760 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x40001277a0 sp=0x4000127780 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x40001277d0 sp=0x40001277a0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40001277d0 sp=0x40001277d0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 50
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 99 gp=0x4000512a80 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005106f0 sp=0x40005106d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000510770 sp=0x40005106f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x40005107a0 sp=0x4000510770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x40005107d0 sp=0x40005107a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005107d0 sp=0x40005107d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 50
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 100 gp=0x4000512c40 m=nil [select]:
+runtime.gopark(0x4000523ac8?, 0x3?, 0xb8?, 0x36?, 0x4000523822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000523670 sp=0x4000523650 pc=0xe7da00
+runtime.selectgo(0x4000523ac8, 0x400052381c, 0x27c9470?, 0x0, 0x27dda18?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005237b0 sp=0x4000523670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x400003d080}, {0xe1a882ce2108, 0x4000506210}, {0x27f5390, 0x24e5520}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000523b30 sp=0x40005237b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40003e6870, {0x0?, 0x0?}, 0x40000b3180, 0x400028a3f0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000523d10 sp=0x4000523b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40003e6870, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000523df0 sp=0x4000523d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000523e20 sp=0x4000523df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000523e40 sp=0x4000523e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000523f40, {0x27c3100, 0x40003ea2d0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000523ec0 sp=0x4000523e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40003e6870, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000523f60 sp=0x4000523ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000523f80 sp=0x4000523f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000523fa0 sp=0x4000523f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000523fd0 sp=0x4000523fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000523fd0 sp=0x4000523fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 50
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 94 gp=0x4000512e00 m=nil [select]:
+runtime.gopark(0x40006e3f40?, 0x3?, 0x68?, 0x3e?, 0x40006e3f22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40006e3d70 sp=0x40006e3d50 pc=0xe7da00
+runtime.selectgo(0x40006e3f40, 0x40006e3f1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40006e3eb0 sp=0x40006e3d70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40003e6870, 0x40000b3180, 0x4000508af0, 0x400028a3f0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x40006e3fa0 sp=0x40006e3eb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x40006e3fd0 sp=0x40006e3fa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40006e3fd0 sp=0x40006e3fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 100
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 73 gp=0x40005828c0 m=nil [chan receive]:
+runtime.gopark(0x4000126e28?, 0x0?, 0x1?, 0x0?, 0x1b047b0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000126e00 sp=0x4000126de0 pc=0xe7da00
+runtime.chanrecv(0x40005802a0, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000126e80 sp=0x4000126e00 pc=0xe13558
+runtime.chanrecv1(0x40003ea0f0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x4000126eb0 sp=0x4000126e80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003ea0f0, 0x40005802a0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x4000126f60 sp=0x4000126eb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000126f80 sp=0x4000126f60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000126fa0 sp=0x4000126f80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000126fd0 sp=0x4000126fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000126fd0 sp=0x4000126fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 55
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 74 gp=0x4000582a80 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050a6f0 sp=0x400050a6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050a770 sp=0x400050a6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050a7a0 sp=0x400050a770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400050a7d0 sp=0x400050a7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050a7d0 sp=0x400050a7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 55
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 75 gp=0x4000582c40 m=nil [select]:
+runtime.gopark(0x4000525ac8?, 0x3?, 0x98?, 0x56?, 0x4000525822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000525670 sp=0x4000525650 pc=0xe7da00
+runtime.selectgo(0x4000525ac8, 0x400052581c, 0x27dda18?, 0x0, 0x400022a400?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005257b0 sp=0x4000525670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x4000672dc0}, {0xe1a882ce2108, 0x40002b20b0}, {0x27f5390, 0x24e2d40}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000525b30 sp=0x40005257b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40005841e0, {0x0?, 0x0?}, 0x40000b3180, 0x40002bc0e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000525d10 sp=0x4000525b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40005841e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000525df0 sp=0x4000525d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000525e20 sp=0x4000525df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000525e40 sp=0x4000525e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000525f40, {0x27c3100, 0x40003f6140}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000525ec0 sp=0x4000525e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40005841e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000525f60 sp=0x4000525ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000525f80 sp=0x4000525f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000525fa0 sp=0x4000525f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000525fd0 sp=0x4000525fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000525fd0 sp=0x4000525fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 55
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 105 gp=0x4000582e00 m=nil [select]:
+runtime.gopark(0x40006e0f40?, 0x3?, 0xa8?, 0xd?, 0x40006e0f22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40006e0d70 sp=0x40006e0d50 pc=0xe7da00
+runtime.selectgo(0x40006e0f40, 0x40006e0f1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40006e0eb0 sp=0x40006e0d70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40005841e0, 0x40000b3180, 0x4000138150, 0x40002bc0e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x40006e0fa0 sp=0x40006e0eb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x40006e0fd0 sp=0x40006e0fa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40006e0fd0 sp=0x40006e0fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 75
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 95 gp=0x4000512fc0 m=nil [select]:
+runtime.gopark(0x400051dee8?, 0x6?, 0x0?, 0xbc?, 0x400051dd84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400051dbd0 sp=0x400051dbb0 pc=0xe7da00
+runtime.selectgo(0x400051dee8, 0x400051dd78, 0x4000000033?, 0x0, 0x8?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400051dd10 sp=0x400051dbd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000500600, 0x4000466a00, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x400051df70 sp=0x400051dd10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000500600, 0x400022f5a0?, 0x400022f5b0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x400051dfa0 sp=0x400051df70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x400051dfd0 sp=0x400051dfa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400051dfd0 sp=0x400051dfd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 100
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 124 gp=0x4000582fc0 m=nil [select]:
+runtime.gopark(0x40005a3ac8?, 0x3?, 0x98?, 0x36?, 0x40005a3822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005a3670 sp=0x40005a3650 pc=0xe7da00
+runtime.selectgo(0x40005a3ac8, 0x40005a381c, 0x27dda18?, 0x0, 0x4000036080?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005a37b0 sp=0x40005a3670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x400003c0c0}, {0xe1a882ce2108, 0x40002b22c0}, {0x27f5390, 0x24e5c60}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x40005a3b30 sp=0x40005a37b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x4000584780, {0x0?, 0x0?}, 0x40000b3180, 0x40002bd500)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x40005a3d10 sp=0x40005a3b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000584780, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x40005a3df0 sp=0x40005a3d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x40005a3e20 sp=0x40005a3df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x40005a3e40 sp=0x40005a3e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x40005a3f40, {0x27c3100, 0x40003f6500}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x40005a3ec0 sp=0x40005a3e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000584780, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x40005a3f60 sp=0x40005a3ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x4000012e40?)
+	<autogenerated>:1 +0x30 fp=0x40005a3f80 sp=0x40005a3f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x40005a3fa0 sp=0x40005a3f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x40005a3fd0 sp=0x40005a3fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005a3fd0 sp=0x40005a3fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 47
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 78 gp=0x4000583180 m=nil [chan receive]:
+runtime.gopark(0x400050ae28?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050ae00 sp=0x400050ade0 pc=0xe7da00
+runtime.chanrecv(0x4000580380, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050ae80 sp=0x400050ae00 pc=0xe13558
+runtime.chanrecv1(0x40003c9e00?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050aeb0 sp=0x400050ae80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9e00, 0x4000580380)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400050af60 sp=0x400050aeb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400050af80 sp=0x400050af60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400050afa0 sp=0x400050af80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400050afd0 sp=0x400050afa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050afd0 sp=0x400050afd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 53
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 79 gp=0x4000583340 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050b6f0 sp=0x400050b6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050b770 sp=0x400050b6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050b7a0 sp=0x400050b770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400050b7d0 sp=0x400050b7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050b7d0 sp=0x400050b7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 53
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 80 gp=0x4000583500 m=nil [select]:
+runtime.gopark(0x4000521ac8?, 0x3?, 0x98?, 0x16?, 0x4000521822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000521670 sp=0x4000521650 pc=0xe7da00
+runtime.selectgo(0x4000521ac8, 0x400052181c, 0x27dda18?, 0x0, 0x4000122720?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005217b0 sp=0x4000521670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x40000a7c80}, {0xe1a882ce2108, 0x40002b2160}, {0x27f5390, 0x24e1780}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x4000521b30 sp=0x40005217b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40005843c0, {0x0?, 0x0?}, 0x40000b3180, 0x400028a150)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x4000521d10 sp=0x4000521b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40005843c0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x4000521df0 sp=0x4000521d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x4000521e20 sp=0x4000521df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x4000521e40 sp=0x4000521e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000521f40, {0x27c3100, 0x40003f61e0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x4000521ec0 sp=0x4000521e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40005843c0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x4000521f60 sp=0x4000521ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x4000521f80 sp=0x4000521f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000521fa0 sp=0x4000521f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000521fd0 sp=0x4000521fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000521fd0 sp=0x4000521fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 53
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 89 gp=0x40005836c0 m=nil [select]:
+runtime.gopark(0x400008bf40?, 0x3?, 0xa8?, 0xbd?, 0x400008bf22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400008bd70 sp=0x400008bd50 pc=0xe7da00
+runtime.selectgo(0x400008bf40, 0x400008bf1c, 0x0?, 0x0, 0x40000b2c40?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400008beb0 sp=0x400008bd70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40005843c0, 0x40000b3180, 0x4000508620, 0x400028a150)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x400008bfa0 sp=0x400008beb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x400008bfd0 sp=0x400008bfa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400008bfd0 sp=0x400008bfd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 80
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 147 gp=0x400047f880 m=nil [select]:
+runtime.gopark(0x400008aee8?, 0x6?, 0x8?, 0xac?, 0x400008ad84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400008abd0 sp=0x400008abb0 pc=0xe7da00
+runtime.selectgo(0x400008aee8, 0x400008ad78, 0x2b?, 0x0, 0x400029c930?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400008ad10 sp=0x400008abd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000620900, 0x4000595540, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x400008af70 sp=0x400008ad10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000620900, 0x1b06900?, 0x400013e020?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x400008afa0 sp=0x400008af70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x400008afd0 sp=0x400008afa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400008afd0 sp=0x400008afd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 24
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 106 gp=0x40006001c0 m=nil [select]:
+runtime.gopark(0x4000091ee8?, 0x6?, 0x8?, 0x1c?, 0x4000091d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000091bd0 sp=0x4000091bb0 pc=0xe7da00
+runtime.selectgo(0x4000091ee8, 0x4000091d78, 0x4000000039?, 0x0, 0x8?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000091d10 sp=0x4000091bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000596000, 0x4000001b80, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000091f70 sp=0x4000091d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000596000, 0x40004942a0?, 0x40004942b0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000091fa0 sp=0x4000091f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000091fd0 sp=0x4000091fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000091fd0 sp=0x4000091fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 75
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 90 gp=0x4000583880 m=nil [select]:
+runtime.gopark(0x400060bee8?, 0x6?, 0x8?, 0xbc?, 0x400060bd84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005acbd0 sp=0x40005acbb0 pc=0xe7da00
+runtime.selectgo(0x40005acee8, 0x400060bd78, 0x2f?, 0x0, 0x1f4?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005acd10 sp=0x40005acbd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000500180, 0x40002d5540, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x40005acf70 sp=0x40005acd10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000500180, 0x40002a0460?, 0x40002a0470?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x40005acfa0 sp=0x40005acf70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x40005acfd0 sp=0x40005acfa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005acfd0 sp=0x40005acfd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 80
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 123 gp=0x4000583a40 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0xf4?, 0x1?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000127ef0 sp=0x4000127ed0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000127f70 sp=0x4000127ef0 pc=0xe13558
+runtime.chanrecv1(0x4000596180?, 0x1b06900?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x4000127fa0 sp=0x4000127f70 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x4000127fd0 sp=0x4000127fa0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000127fd0 sp=0x4000127fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 47
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 116 gp=0x4000583c00 m=nil [chan receive]:
+runtime.gopark(0x400050be28?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050be00 sp=0x400050bde0 pc=0xe7da00
+runtime.chanrecv(0x4000580620, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050be80 sp=0x400050be00 pc=0xe13558
+runtime.chanrecv1(0x40003c9e50?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050beb0 sp=0x400050be80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9e50, 0x4000580620)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400050bf60 sp=0x400050beb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400050bf80 sp=0x400050bf60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400050bfa0 sp=0x400050bf80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400050bfd0 sp=0x400050bfa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050bfd0 sp=0x400050bfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 54
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 117 gp=0x4000583dc0 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400050c6f0 sp=0x400050c6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400050c770 sp=0x400050c6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400050c7a0 sp=0x400050c770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400050c7d0 sp=0x400050c7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400050c7d0 sp=0x400050c7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 54
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 118 gp=0x400059a000 m=nil [select]:
+runtime.gopark(0x40005a1ac8?, 0x3?, 0x98?, 0x16?, 0x40005a1822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005a1670 sp=0x40005a1650 pc=0xe7da00
+runtime.selectgo(0x40005a1ac8, 0x40005a181c, 0x27dda18?, 0x0, 0x4000037360?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005a17b0 sp=0x40005a1670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x400003d200}, {0xe1a882ce2108, 0x40002b2210}, {0x27f5390, 0x24e1b20}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x40005a1b30 sp=0x40005a17b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40005845a0, {0x0?, 0x0?}, 0x40000b3180, 0x40002bc460)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x40005a1d10 sp=0x40005a1b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40005845a0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x40005a1df0 sp=0x40005a1d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x40005a1e20 sp=0x40005a1df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x40005a1e40 sp=0x40005a1e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x40005a1f40, {0x27c3100, 0x40003f63c0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x40005a1ec0 sp=0x40005a1e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40005845a0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x40005a1f60 sp=0x40005a1ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x40005a1f80 sp=0x40005a1f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x40005a1fa0 sp=0x40005a1f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x40005a1fd0 sp=0x40005a1fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005a1fd0 sp=0x40005a1fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 54
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 136 gp=0x400059a1c0 m=nil [select]:
+runtime.gopark(0x40005aef40?, 0x3?, 0xa8?, 0xed?, 0x40005aef22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005aed70 sp=0x40005aed50 pc=0xe7da00
+runtime.selectgo(0x40005aef40, 0x40005aef1c, 0x40005aef40?, 0x0, 0x40003f65a0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005aeeb0 sp=0x40005aed70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40005845a0, 0x40000b3180, 0x4000138c40, 0x40002bc460)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x40005aefa0 sp=0x40005aeeb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x40005aefd0 sp=0x40005aefa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005aefd0 sp=0x40005aefd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 118
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 29 gp=0x400047fdc0 m=nil [chan receive]:
+runtime.gopark(0x400012ce28?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012ce00 sp=0x400012cde0 pc=0xe7da00
+runtime.chanrecv(0x4000138540, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400012ce80 sp=0x400012ce00 pc=0xe13558
+runtime.chanrecv1(0x40003c9ea0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400012ceb0 sp=0x400012ce80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9ea0, 0x4000138540)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x400012cf60 sp=0x400012ceb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400012cf80 sp=0x400012cf60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400012cfa0 sp=0x400012cf80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400012cfd0 sp=0x400012cfa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012cfd0 sp=0x400012cfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 49
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 30 gp=0x400016a000 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012d6f0 sp=0x400012d6d0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x400012d770 sp=0x400012d6f0 pc=0xe13558
+runtime.chanrecv1(0x0?, 0x0?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x400012d7a0 sp=0x400012d770 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x400012d7d0 sp=0x400012d7a0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012d7d0 sp=0x400012d7d0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 49
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 31 gp=0x400016a1c0 m=nil [select]:
+runtime.gopark(0x400059dac8?, 0x3?, 0x98?, 0xd6?, 0x400059d822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400059d670 sp=0x400059d650 pc=0xe7da00
+runtime.selectgo(0x400059dac8, 0x400059d81c, 0x27dda18?, 0x0, 0x4000037300?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400059d7b0 sp=0x400059d670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x400003d140}, {0xe1a882ce2108, 0x400013c0b0}, {0x27f5390, 0x24e30e0}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x400059db30 sp=0x400059d7b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x40001401e0, {0x0?, 0x0?}, 0x40000b3180, 0x400029ca80)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x400059dd10 sp=0x400059db30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40001401e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x400059ddf0 sp=0x400059dd10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x400059de20 sp=0x400059ddf0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000081808?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x400059de40 sp=0x400059de20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x400059df40, {0x27c3100, 0x40001d0550}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x400059dec0 sp=0x400059de40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x40001401e0, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x400059df60 sp=0x400059dec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x400059df80 sp=0x400059df60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x400059dfa0 sp=0x400059df80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x400059dfd0 sp=0x400059dfa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400059dfd0 sp=0x400059dfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 49
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 148 gp=0x400016a380 m=nil [select]:
+runtime.gopark(0x4000518f40?, 0x3?, 0xa8?, 0x8d?, 0x4000518f22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000518d70 sp=0x4000518d50 pc=0xe7da00
+runtime.selectgo(0x4000518f40, 0x4000518f1c, 0x4000580618?, 0x0, 0x40000b2c40?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000518eb0 sp=0x4000518d70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x40001401e0, 0x40000b3180, 0x4000022770, 0x400029ca80)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x4000518fa0 sp=0x4000518eb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x4000518fd0 sp=0x4000518fa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000518fd0 sp=0x4000518fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 31
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 137 gp=0x400059a380 m=nil [select]:
+runtime.gopark(0x400051bee8?, 0x6?, 0x8?, 0xbc?, 0x400051bd84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400051bbd0 sp=0x400051bbb0 pc=0xe7da00
+runtime.selectgo(0x400051bee8, 0x400051bd78, 0x2d?, 0x0, 0x1f4?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400051bd10 sp=0x400051bbd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000596a80, 0x400061f680, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x400051bf70 sp=0x400051bd10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000596a80, 0x40002a0700?, 0x40002a0710?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x400051bfa0 sp=0x400051bf70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x400051bfd0 sp=0x400051bfa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400051bfd0 sp=0x400051bfd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 118
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 149 gp=0x400016a540 m=nil [select]:
+runtime.gopark(0x4000516ee8?, 0x6?, 0x8?, 0x6c?, 0x4000516d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000516bd0 sp=0x4000516bb0 pc=0xe7da00
+runtime.selectgo(0x4000516ee8, 0x4000516d78, 0x31?, 0x0, 0x1f4?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000516d10 sp=0x4000516bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000620a80, 0x4000595900, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000516f70 sp=0x4000516d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000620a80, 0x40000507a0?, 0x40000507b0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000516fa0 sp=0x4000516f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000516fd0 sp=0x4000516fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000516fd0 sp=0x4000516fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 31
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 138 gp=0x400059a540 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x27e5210?, 0x3731008?, 0x18?, 0xb?, 0xe19e74?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000170ab0 sp=0x4000170a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x40005967c8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000170b00 sp=0x4000170ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x40005967b8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000170b30 sp=0x4000170b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x40005967b0, {0x4000498200, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x4000170ba0 sp=0x4000170b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000170c98?}, {0x4000498200?, 0x4000512700?, 0x4?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x4000170c30 sp=0x4000170ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x400061f900)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x4000170c80 sp=0x4000170c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x400061f900)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x4000170cd0 sp=0x4000170c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x400061f900, {0x2289cc0, 0x400045f080})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x4000170d00 sp=0x4000170cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40004a8c90, {0x40004d8000, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x4000170d50 sp=0x4000170d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003ea3c0, 0x0, {0x27c7338, 0x40002c1600})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x4000170e00 sp=0x4000170d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x400022aec0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x4000170e60 sp=0x4000170e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x40002c15c0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x4000170fb0 sp=0x4000170e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x4000170fd0 sp=0x4000170fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000170fd0 sp=0x4000170fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 62
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 133 gp=0x400059a700 m=nil [select]:
+runtime.gopark(0x4000351ee8?, 0x6?, 0x8?, 0x1c?, 0x4000351d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000351bd0 sp=0x4000351bb0 pc=0xe7da00
+runtime.selectgo(0x4000351ee8, 0x4000351d78, 0x25?, 0x0, 0x40002bc1c0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000351d10 sp=0x4000351bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000596780, 0x400061ef00, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000351f70 sp=0x4000351d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000596780, 0x1b06900?, 0x4000286b90?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000351fa0 sp=0x4000351f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000351fd0 sp=0x4000351fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000351fd0 sp=0x4000351fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 62
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 128 gp=0x400059a8c0 m=nil [chan receive]:
+runtime.gopark(0x4000128e28?, 0x4000584780?, 0x38?, 0x8e?, 0x1b047b0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000128e00 sp=0x4000128de0 pc=0xe7da00
+runtime.chanrecv(0x4000580b60, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000128e80 sp=0x4000128e00 pc=0xe13558
+runtime.chanrecv1(0x40003c9d10?, 0x1f55120?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x4000128eb0 sp=0x4000128e80 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0x40003c9d10, 0x4000580b60)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/shared_informer.go:802 +0x3c fp=0x4000128f60 sp=0x4000128eb0 pc=0x1f4eb9c
+k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm(0x4000012e40?)
+	<autogenerated>:1 +0x30 fp=0x4000128f80 sp=0x4000128f60 pc=0x1f54ff0
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run.(*Group).StartWithChannel.func4()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x4000128fa0 sp=0x4000128f80 pc=0x1f4c294
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x4000128fd0 sp=0x4000128fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000128fd0 sp=0x4000128fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 48
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 129 gp=0x400059aa80 m=nil [chan receive]:
+runtime.gopark(0x27ea1a0?, 0x40002b22c0?, 0x90?, 0x6c?, 0x400022d278?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000078ef0 sp=0x4000078ed0 pc=0xe7da00
+runtime.chanrecv(0x40000b3180, 0x0, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000078f70 sp=0x4000078ef0 pc=0xe13558
+runtime.chanrecv1(0x1000040000b33b0?, 0x1fb4690?)
+	/snap/go/10988/src/runtime/chan.go:509 +0x14 fp=0x4000078fa0 sp=0x4000078f70 pc=0xe130f4
+k8s.io/client-go/tools/cache.(*controller).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:133 +0x28 fp=0x4000078fd0 sp=0x4000078fa0 pc=0x1f41248
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000078fd0 sp=0x4000078fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*controller).Run in goroutine 48
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/controller.go:132 +0x8c
+
+goroutine 130 gp=0x400059ac40 m=nil [select]:
+runtime.gopark(0x40005b5ac8?, 0x3?, 0x98?, 0x56?, 0x40005b5822?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005b5670 sp=0x40005b5650 pc=0xe7da00
+runtime.selectgo(0x40005b5ac8, 0x40005b581c, 0x27dda18?, 0x0, 0x4000122780?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x40005b57b0 sp=0x40005b5670 pc=0xe5c11c
+k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x370d720?}, {0x27c7860, 0x40000a7d40}, {0xe1a882ce2108, 0x40002b2370}, {0x27f5390, 0x24e58c0}, 0x0, ...)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:712 +0x120 fp=0x40005b5b30 sp=0x40005b57b0 pc=0x1f49790
+k8s.io/client-go/tools/cache.(*Reflector).watch(0x4000584960, {0x0?, 0x0?}, 0x40000b3180, 0x40002bc310)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:431 +0x384 fp=0x40005b5d10 sp=0x40005b5b30 pc=0x1f47aa4
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000584960, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:356 +0x2a4 fp=0x40005b5df0 sp=0x40005b5d10 pc=0x1f47354
+k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:289 +0x24 fp=0x40005b5e20 sp=0x40005b5df0 pc=0x1f46fa4
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x4000100008?)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:226 +0x40 fp=0x40005b5e40 sp=0x40005b5e20 pc=0x1b048d0
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x40005b5f40, {0x27c3100, 0x40003f65a0}, 0x1, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/backoff.go:227 +0x90 fp=0x40005b5ec0 sp=0x40005b5e40 pc=0x1b047b0
+k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000584960, 0x40000b3180)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:288 +0x158 fp=0x40005b5f60 sp=0x40005b5ec0 pc=0x1f46e48
+k8s.io/client-go/tools/cache.(*Reflector).Run-fm(0x0?)
+	<autogenerated>:1 +0x30 fp=0x40005b5f80 sp=0x40005b5f60 pc=0x1f55120
+k8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:55 +0x24 fp=0x40005b5fa0 sp=0x40005b5f80 pc=0x1f41204
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:72 +0x4c fp=0x40005b5fd0 sp=0x40005b5fa0 pc=0x1b068bc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005b5fd0 sp=0x40005b5fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 48
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/wait/wait.go:70 +0x74
+
+goroutine 134 gp=0x400059ae00 m=nil [select]:
+runtime.gopark(0x400016df40?, 0x3?, 0xa8?, 0xdd?, 0x400016df22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400016dd70 sp=0x400016dd50 pc=0xe7da00
+runtime.selectgo(0x400016df40, 0x400016df1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400016deb0 sp=0x400016dd70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x4000584960, 0x40000b3180, 0x4000138a10, 0x40002bc310)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x400016dfa0 sp=0x400016deb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x400016dfd0 sp=0x400016dfa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400016dfd0 sp=0x400016dfd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 130
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 104 gp=0x400016a8c0 m=nil [select]:
+runtime.gopark(0x4000135ee8?, 0x6?, 0x8?, 0x5c?, 0x4000135d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000135bd0 sp=0x4000135bb0 pc=0xe7da00
+runtime.selectgo(0x4000135ee8, 0x4000135d78, 0x27?, 0x0, 0x1f4?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000135d10 sp=0x4000135bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000166600, 0x4000165180, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000135f70 sp=0x4000135d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000166600, 0x400022f5a0?, 0x400022f5b0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000135fa0 sp=0x4000135f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000135fd0 sp=0x4000135fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000135fd0 sp=0x4000135fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 69
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 93 gp=0x4000513180 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40006e2ab0 sp=0x40006e2a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000166648, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x40006e2b00 sp=0x40006e2ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000166638)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x40006e2b30 sp=0x40006e2b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000166630, {0x4000228600, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x40006e2ba0 sp=0x40006e2b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x400012b498?}, {0x4000228600?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x40006e2c30 sp=0x40006e2ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000466500)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x40006e2c80 sp=0x40006e2c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000466500)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x40006e2cd0 sp=0x40006e2c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000466500, {0x2289cc0, 0x40000117d0})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x40006e2d00 sp=0x40006e2cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40002cdd40, {0x4000700c00, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x40006e2d50 sp=0x40006e2d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x400040a730, 0x0, {0x27c7338, 0x40000a7f00})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x40006e2e00 sp=0x40006e2d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x40001227e0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x40006e2e60 sp=0x40006e2e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x40000a7ec0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x40006e2fb0 sp=0x40006e2e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x40006e2fd0 sp=0x40006e2fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40006e2fd0 sp=0x40006e2fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 69
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 150 gp=0x400059b340 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000173ab0 sp=0x4000173a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000500648, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x4000173b00 sp=0x4000173ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000500638)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x4000173b30 sp=0x4000173b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000500630, {0x400062ca00, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x4000173ba0 sp=0x4000173b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000786c98?}, {0x400062ca00?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x4000173c30 sp=0x4000173ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000595cc0)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x4000173c80 sp=0x4000173c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000595cc0)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x4000173cd0 sp=0x4000173c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000595cc0, {0x2289cc0, 0x40006a0d20})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x4000173d00 sp=0x4000173cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40006fec30, {0x40006acc00, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x4000173d50 sp=0x4000173d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003f68c0, 0x0, {0x27c7338, 0x400003d0c0})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x4000173e00 sp=0x4000173d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x40000372a0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x4000173e60 sp=0x4000173e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x400003d080)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x4000173fb0 sp=0x4000173e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x4000173fd0 sp=0x4000173fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000173fd0 sp=0x4000173fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 100
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 151 gp=0x400059b500 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005a8ab0 sp=0x40005a8a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000620ac8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x40005a8b00 sp=0x40005a8ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000620ab8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x40005a8b30 sp=0x40005a8b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000620ab0, {0x400062cc00, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x40005a8ba0 sp=0x40005a8b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000786c98?}, {0x400062cc00?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x40005a8c30 sp=0x40005a8ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000595e00)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x40005a8c80 sp=0x40005a8c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000595e00)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x40005a8cd0 sp=0x40005a8c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000595e00, {0x2289cc0, 0x40006a0d50})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x40005a8d00 sp=0x40005a8cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40006fecc0, {0x40006ad000, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x40005a8d50 sp=0x40005a8d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003f6910, 0x0, {0x27c7338, 0x400003d180})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x40005a8e00 sp=0x40005a8d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000037300)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x40005a8e60 sp=0x40005a8e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x400003d140)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x40005a8fb0 sp=0x40005a8e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x40005a8fd0 sp=0x40005a8fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005a8fd0 sp=0x40005a8fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 31
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 152 gp=0x400059b6c0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005a9ab0 sp=0x40005a9a90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000596ac8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x40005a9b00 sp=0x40005a9ab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000596ab8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x40005a9b30 sp=0x40005a9b00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000596ab0, {0x400062ce00, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x40005a9ba0 sp=0x40005a9b30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000786c98?}, {0x400062ce00?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x40005a9c30 sp=0x40005a9ba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000298140)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x40005a9c80 sp=0x40005a9c30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000298140)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x40005a9cd0 sp=0x40005a9c80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000298140, {0x2289cc0, 0x40006a0d80})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x40005a9d00 sp=0x40005a9cd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40006fed50, {0x40006ad400, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x40005a9d50 sp=0x40005a9d00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003f6960, 0x0, {0x27c7338, 0x400003d240})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x40005a9e00 sp=0x40005a9d50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000037360)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x40005a9e60 sp=0x40005a9e00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x400003d200)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x40005a9fb0 sp=0x40005a9e60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x40005a9fd0 sp=0x40005a9fb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005a9fd0 sp=0x40005a9fd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 118
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 153 gp=0x400059b880 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40005aaab0 sp=0x40005aaa90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000620948, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x40005aab00 sp=0x40005aaab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000620938)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x40005aab30 sp=0x40005aab00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000620930, {0x400062d000, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x40005aaba0 sp=0x40005aab30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000786c98?}, {0x400062d000?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x40005aac30 sp=0x40005aaba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000298280)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x40005aac80 sp=0x40005aac30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000298280)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x40005aacd0 sp=0x40005aac80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000298280, {0x2289cc0, 0x40006a0db0})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x40005aad00 sp=0x40005aacd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40006fede0, {0x40006ad800, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x40005aad50 sp=0x40005aad00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003f6a50, 0x0, {0x27c7338, 0x400003d300})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x40005aae00 sp=0x40005aad50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x40000373c0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x40005aae60 sp=0x40005aae00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x400003d2c0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x40005aafb0 sp=0x40005aae60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x40005aafd0 sp=0x40005aafb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40005aafd0 sp=0x40005aafd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 24
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 154 gp=0x400059ba40 m=nil [select]:
+runtime.gopark(0x4000786f40?, 0x3?, 0x68?, 0x6e?, 0x4000786f22?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000786d70 sp=0x4000786d50 pc=0xe7da00
+runtime.selectgo(0x4000786f40, 0x4000786f1c, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000786eb0 sp=0x4000786d70 pc=0xe5c11c
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0x4000034000, 0x40000b3180, 0x4000022d90, 0x400029caf0)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:368 +0xb4 fp=0x4000786fa0 sp=0x4000786eb0 pc=0x1f47564
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch.gowrap2()
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x2c fp=0x4000786fd0 sp=0x4000786fa0 pc=0x1f4741c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000786fd0 sp=0x4000786fd0 pc=0xe857d4
+created by k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch in goroutine 85
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/tools/cache/reflector.go:355 +0x28c
+
+goroutine 155 gp=0x400059bc00 m=nil [select]:
+runtime.gopark(0x4000090ee8?, 0x6?, 0xc0?, 0xbd?, 0x4000090d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000090bd0 sp=0x4000090bb0 pc=0xe7da00
+runtime.selectgo(0x4000090ee8, 0x4000090d78, 0x35?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000090d10 sp=0x4000090bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000620c00, 0x40002988c0, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000090f70 sp=0x4000090d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000620c00, 0x0?, 0x0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000090fa0 sp=0x4000090f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000090fd0 sp=0x4000090fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000090fd0 sp=0x4000090fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 85
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 156 gp=0x400059bdc0 m=nil [select]:
+runtime.gopark(0x4000807ee8?, 0x6?, 0x8?, 0x7c?, 0x4000807d84?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000807bd0 sp=0x4000807bb0 pc=0xe7da00
+runtime.selectgo(0x4000807ee8, 0x4000807d78, 0x37?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000807d10 sp=0x4000807bd0 pc=0xe5c11c
+golang.org/x/net/http2.(*clientStream).writeRequest(0x4000620d80, 0x40000017c0, 0x0)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1570 +0x9a8 fp=0x4000807f70 sp=0x4000807d10 pc=0x13274c8
+golang.org/x/net/http2.(*clientStream).doRequest(0x4000620d80, 0x0?, 0x0?)
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1431 +0x54 fp=0x4000807fa0 sp=0x4000807f70 pc=0x1326ae4
+golang.org/x/net/http2.(*ClientConn).roundTrip.gowrap1()
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x2c fp=0x4000807fd0 sp=0x4000807fa0 pc=0x1326a5c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000807fd0 sp=0x4000807fd0 pc=0xe857d4
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 124
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:1336 +0x3a4
+
+goroutine 96 gp=0x4000513340 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400051cab0 sp=0x400051ca90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000620c48, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400051cb00 sp=0x400051cab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000620c38)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400051cb30 sp=0x400051cb00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000620c30, {0x4000228800, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x400051cba0 sp=0x400051cb30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x400012b498?}, {0x4000228800?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x400051cc30 sp=0x400051cba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000466c80)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x400051cc80 sp=0x400051cc30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000466c80)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x400051ccd0 sp=0x400051cc80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000466c80, {0x2289cc0, 0x40007143d8})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x400051cd00 sp=0x400051ccd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x4000720030, {0x4000701000, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x400051cd50 sp=0x400051cd00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x400040a870, 0x0, {0x27c7338, 0x4000453700})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x400051ce00 sp=0x400051cd50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000122e80)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x400051ce60 sp=0x400051ce00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000453640)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x400051cfb0 sp=0x400051ce60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x400051cfd0 sp=0x400051cfb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400051cfd0 sp=0x400051cfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 85
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 157 gp=0x40006016c0 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x27f5390?, 0x3731008?, 0x18?, 0xab?, 0xe19e74?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400034aab0 sp=0x400034aa90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000620dc8, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400034ab00 sp=0x400034aab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000620db8)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400034ab30 sp=0x400034ab00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000620db0, {0x4000498400, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x400034aba0 sp=0x400034ab30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000126498?}, {0x4000498400?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x400034ac30 sp=0x400034aba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000298b40)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x400034ac80 sp=0x400034ac30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000298b40)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x400034acd0 sp=0x400034ac80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000298b40, {0x2289cc0, 0x4000714420})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x400034ad00 sp=0x400034acd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x40006fe210, {0x40004d8400, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x400034ad50 sp=0x400034ad00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003ea280, 0x0, {0x27c7338, 0x400003c100})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x400034ae00 sp=0x400034ad50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000036080)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x400034ae60 sp=0x400034ae00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x400003c0c0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x400034afb0 sp=0x400034ae60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x400034afd0 sp=0x400034afb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400034afd0 sp=0x400034afd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 124
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 107 gp=0x4000513500 m=nil [sync.Cond.Wait]:
+runtime.gopark(0x0?, 0x3731008?, 0x18?, 0xdb?, 0xe19e74?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400034dab0 sp=0x400034da90 pc=0xe7da00
+runtime.goparkunlock(...)
+	/snap/go/10988/src/runtime/proc.go:466
+sync.runtime_notifyListWait(0x4000596048, 0x0)
+	/snap/go/10988/src/runtime/sema.go:606 +0x140 fp=0x400034db00 sp=0x400034dab0 pc=0xe7f2e0
+sync.(*Cond).Wait(0x4000596038)
+	/snap/go/10988/src/sync/cond.go:71 +0xa4 fp=0x400034db30 sp=0x400034db00 pc=0xe9f124
+golang.org/x/net/http2.(*pipe).Read(0x4000596030, {0x400062c000, 0x200, 0x200})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/pipe.go:76 +0xf4 fp=0x400034dba0 sp=0x400034db30 pc=0x131f9a4
+golang.org/x/net/http2.transportResponseBody.Read({0x4000787c98?}, {0x400062c000?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/golang.org/x/net@v0.38.0/http2/transport.go:2560 +0x4c fp=0x400034dc30 sp=0x400034dba0 pc=0x132c63c
+encoding/json.(*Decoder).refill(0x4000001e00)
+	/snap/go/10988/src/encoding/json/stream.go:167 +0x144 fp=0x400034dc80 sp=0x400034dc30 pc=0x102a0a4
+encoding/json.(*Decoder).readValue(0x4000001e00)
+	/snap/go/10988/src/encoding/json/stream.go:142 +0x70 fp=0x400034dcd0 sp=0x400034dc80 pc=0x1029d00
+encoding/json.(*Decoder).Decode(0x4000001e00, {0x2289cc0, 0x400065bad0})
+	/snap/go/10988/src/encoding/json/stream.go:65 +0x5c fp=0x400034dd00 sp=0x400034dcd0 pc=0x1029a1c
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x400078c7b0, {0x40006ac000, 0x400, 0x400})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/util/framer/framer.go:152 +0x188 fp=0x400034dd50 sp=0x400034dd00 pc=0x15b0c58
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40003f60f0, 0x0, {0x27c7338, 0x4000672e00})
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/streaming/streaming.go:77 +0x80 fp=0x400034de00 sp=0x400034dd50 pc=0x1b1e740
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0x400022a400)
+	/home/vladimir/go/pkg/mod/k8s.io/client-go@v0.27.4/rest/watch/decoder.go:49 +0x54 fp=0x400034de60 sp=0x400034de00 pc=0x1b1ea44
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000672dc0)
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:105 +0x98 fp=0x400034dfb0 sp=0x400034de60 pc=0x1339058
+k8s.io/apimachinery/pkg/watch.NewStreamWatcher.gowrap1()
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0x28 fp=0x400034dfd0 sp=0x400034dfb0 pc=0x1338dd8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400034dfd0 sp=0x400034dfd0 pc=0xe857d4
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher in goroutine 75
+	/home/vladimir/go/pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/watch/streamwatcher.go:76 +0xf4
+
+goroutine 109 gp=0x4000513880 m=nil [runnable]:
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:15 +0x288 fp=0x4079881fc0 sp=0x4079881fc0 pc=0x1fc62d8
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882020 sp=0x4079881fc0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798820d0 sp=0x4079882020 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882130 sp=0x40798820d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798821e0 sp=0x4079882130 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882240 sp=0x40798821e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798822f0 sp=0x4079882240 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882350 sp=0x40798822f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882400 sp=0x4079882350 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882460 sp=0x4079882400 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882510 sp=0x4079882460 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882570 sp=0x4079882510 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882620 sp=0x4079882570 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882680 sp=0x4079882620 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882730 sp=0x4079882680 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882790 sp=0x4079882730 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882840 sp=0x4079882790 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40798828a0 sp=0x4079882840 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882950 sp=0x40798828a0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40798829b0 sp=0x4079882950 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882a60 sp=0x40798829b0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882ac0 sp=0x4079882a60 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882b70 sp=0x4079882ac0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882bd0 sp=0x4079882b70 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882c80 sp=0x4079882bd0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882ce0 sp=0x4079882c80 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882d90 sp=0x4079882ce0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882df0 sp=0x4079882d90 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882ea0 sp=0x4079882df0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079882f00 sp=0x4079882ea0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079882fb0 sp=0x4079882f00 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883010 sp=0x4079882fb0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798830c0 sp=0x4079883010 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883120 sp=0x40798830c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798831d0 sp=0x4079883120 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883230 sp=0x40798831d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798832e0 sp=0x4079883230 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883340 sp=0x40798832e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40798833f0 sp=0x4079883340 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883450 sp=0x40798833f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079883500 sp=0x4079883450 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883560 sp=0x4079883500 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079883610 sp=0x4079883560 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883670 sp=0x4079883610 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079883720 sp=0x4079883670 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883780 sp=0x4079883720 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079883830 sp=0x4079883780 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x4079883890 sp=0x4079883830 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x4079883940 sp=0x4079883890 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40798839a0 sp=0x4079883940 pc=0x1fe0e30
+...2225044 frames elided...
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x4000703b90?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x40006d4188?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a0f0 sp=0x408b91a040 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000712750?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a150 sp=0x408b91a0f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40006d4258?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x2183542?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a200 sp=0x408b91a150 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x248c280?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a260 sp=0x408b91a200 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x2?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x40006d43b8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a310 sp=0x408b91a260 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a370 sp=0x408b91a310 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a420 sp=0x408b91a370 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a480 sp=0x408b91a420 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a530 sp=0x408b91a480 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a590 sp=0x408b91a530 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a640 sp=0x408b91a590 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a6a0 sp=0x408b91a640 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a750 sp=0x408b91a6a0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a7b0 sp=0x408b91a750 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a860 sp=0x408b91a7b0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a8c0 sp=0x408b91a860 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91a970 sp=0x408b91a8c0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91a9d0 sp=0x408b91a970 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91aa80 sp=0x408b91a9d0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91aae0 sp=0x408b91aa80 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91ab90 sp=0x408b91aae0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91abf0 sp=0x408b91ab90 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91aca0 sp=0x408b91abf0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91ad00 sp=0x408b91aca0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91adb0 sp=0x408b91ad00 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91ae10 sp=0x408b91adb0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91aec0 sp=0x408b91ae10 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91af20 sp=0x408b91aec0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91afd0 sp=0x408b91af20 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b030 sp=0x408b91afd0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b148?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b0e0 sp=0x408b91b030 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x214228?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b140 sp=0x408b91b0e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b268?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b1f0 sp=0x408b91b140 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b298?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b250 sp=0x408b91b1f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400060b338?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b348?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b300 sp=0x408b91b250 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b408?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b360 sp=0x408b91b300 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b4b8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b410 sp=0x408b91b360 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x3738260?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b470 sp=0x408b91b410 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40005860d0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x3738260?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b520 sp=0x408b91b470 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000101008?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b580 sp=0x408b91b520 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x19?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b678?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b630 sp=0x408b91b580 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b708?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b690 sp=0x408b91b630 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x10060b7e0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000101008?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b740 sp=0x408b91b690 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x40002a0001?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b7a0 sp=0x408b91b740 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400049d080?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b8d8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b850 sp=0x408b91b7a0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060b958?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x408b91b8b0 sp=0x408b91b850 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40004537c0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27fef80?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x408b91b960 sp=0x408b91b8b0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/k8s.(*Controller).refreshSummary(0x40003e6000, {0x27ddb30, 0x400048a9b0}, 0x400022f0b0)
+	/home/vladimir/DEV/ktop/k8s/summary_controller.go:66 +0x4bc fp=0x408b91bf20 sp=0x408b91b960 pc=0x1fc887c
+github.com/vladimirvivien/ktop/k8s.(*Controller).setupSummaryHandler.func1()
+	/home/vladimir/DEV/ktop/k8s/summary_controller.go:15 +0x40 fp=0x408b91bfd0 sp=0x408b91bf20 pc=0x1fc8280
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x408b91bfd0 sp=0x408b91bfd0 pc=0xe857d4
+created by github.com/vladimirvivien/ktop/k8s.(*Controller).setupSummaryHandler in goroutine 46
+	/home/vladimir/DEV/ktop/k8s/summary_controller.go:14 +0x84
+
+goroutine 110 gp=0x4000513a40 m=nil [runnable]:
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:15 +0x288 fp=0x409b91c380 sp=0x409b91c380 pc=0x1fc62d8
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c3e0 sp=0x409b91c380 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c490 sp=0x409b91c3e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c4f0 sp=0x409b91c490 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c5a0 sp=0x409b91c4f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c600 sp=0x409b91c5a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c6b0 sp=0x409b91c600 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c710 sp=0x409b91c6b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c7c0 sp=0x409b91c710 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c820 sp=0x409b91c7c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c8d0 sp=0x409b91c820 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91c930 sp=0x409b91c8d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91c9e0 sp=0x409b91c930 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91ca40 sp=0x409b91c9e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91caf0 sp=0x409b91ca40 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91cb50 sp=0x409b91caf0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91cc00 sp=0x409b91cb50 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91cc60 sp=0x409b91cc00 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91cd10 sp=0x409b91cc60 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91cd70 sp=0x409b91cd10 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91ce20 sp=0x409b91cd70 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91ce80 sp=0x409b91ce20 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91cf30 sp=0x409b91ce80 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91cf90 sp=0x409b91cf30 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d040 sp=0x409b91cf90 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d0a0 sp=0x409b91d040 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d150 sp=0x409b91d0a0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d1b0 sp=0x409b91d150 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d260 sp=0x409b91d1b0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d2c0 sp=0x409b91d260 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d370 sp=0x409b91d2c0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d3d0 sp=0x409b91d370 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d480 sp=0x409b91d3d0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d4e0 sp=0x409b91d480 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d590 sp=0x409b91d4e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d5f0 sp=0x409b91d590 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d6a0 sp=0x409b91d5f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d700 sp=0x409b91d6a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d7b0 sp=0x409b91d700 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d810 sp=0x409b91d7b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d8c0 sp=0x409b91d810 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91d920 sp=0x409b91d8c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91d9d0 sp=0x409b91d920 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91da30 sp=0x409b91d9d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91dae0 sp=0x409b91da30 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91db40 sp=0x409b91dae0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91dbf0 sp=0x409b91db40 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91dc50 sp=0x409b91dbf0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x409b91dd00 sp=0x409b91dc50 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x409b91dd60 sp=0x409b91dd00 pc=0x1fe0e30
+...1973679 frames elided...
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000062378?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a2e0 sp=0x40ab91a280 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a390 sp=0x40ab91a2e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a3f0 sp=0x40ab91a390 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a4a0 sp=0x40ab91a3f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a500 sp=0x40ab91a4a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060c658?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a5b0 sp=0x40ab91a500 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x372f358?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a610 sp=0x40ab91a5b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x300000000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x3738260?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a6c0 sp=0x40ab91a610 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x500101008?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a720 sp=0x40ab91a6c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400060c828?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a7d0 sp=0x40ab91a720 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x34?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a830 sp=0x40ab91a7d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400060c901?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27f5390?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a8e0 sp=0x40ab91a830 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x249aaa0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91a940 sp=0x40ab91a8e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40004aa6e8?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060ca68?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91a9f0 sp=0x40ab91a940 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27f5390?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91aa50 sp=0x40ab91a9f0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x2?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x2?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91ab00 sp=0x40ab91aa50 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400060cbe8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91ab60 sp=0x40ab91ab00 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x220ca4c?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000145640?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91ac10 sp=0x40ab91ab60 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91ac70 sp=0x40ab91ac10 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x204e907?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91ad20 sp=0x40ab91ac70 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91ad80 sp=0x40ab91ad20 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91ae30 sp=0x40ab91ad80 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91ae90 sp=0x40ab91ae30 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x2112780?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91af40 sp=0x40ab91ae90 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91afa0 sp=0x40ab91af40 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x24d75e0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x40002bc070?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b050 sp=0x40ab91afa0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x5?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b0b0 sp=0x40ab91b050 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x20?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b160 sp=0x40ab91b0b0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b1c0 sp=0x40ab91b160 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b270 sp=0x40ab91b1c0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x10060d348?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b2d0 sp=0x40ab91b270 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b380 sp=0x40ab91b2d0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b3e0 sp=0x40ab91b380 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x255eea8?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b490 sp=0x40ab91b3e0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x254bf73?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b4f0 sp=0x40ab91b490 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x69537511074b6367?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x28?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b5a0 sp=0x40ab91b4f0 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b600 sp=0x40ab91b5a0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400034b758?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b6b0 sp=0x40ab91b600 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000100008?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b710 sp=0x40ab91b6b0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x19?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x3738260?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b7c0 sp=0x40ab91b710 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400034b898?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b820 sp=0x40ab91b7c0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x60034b970?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x4000100008?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b8d0 sp=0x40ab91b820 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x400028a401?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91b930 sp=0x40ab91b8d0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x400049d1d0?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x24e5c60?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91b9e0 sp=0x40ab91b930 pc=0x1fc6088
+github.com/vladimirvivien/ktop/metrics/k8s.(*MetricsServerSource).GetNodeMetrics(0x4000453f00, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27e38b0?})
+	/home/vladimir/DEV/ktop/metrics/k8s/metrics_server_source.go:35 +0x30 fp=0x40ab91ba40 sp=0x40ab91b9e0 pc=0x1fe0e30
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeMetrics(0x40003e6000?, {0x27ddb30?, 0x400048a9b0?}, {0x40004ec3a8?, 0x27f5390?})
+	/home/vladimir/DEV/ktop/k8s/metrics_controller.go:22 +0x38 fp=0x40ab91baf0 sp=0x40ab91ba40 pc=0x1fc6088
+github.com/vladimirvivien/ktop/k8s.(*Controller).GetNodeModels(0x40003e6000, {0x27ddb30, 0x400048a9b0})
+	/home/vladimir/DEV/ktop/k8s/nodes_controller.go:55 +0x138 fp=0x40ab91bee0 sp=0x40ab91baf0 pc=0x1fc7038
+github.com/vladimirvivien/ktop/k8s.(*Controller).refreshNodes(0x0?, {0x27ddb30, 0x400048a9b0}, 0x400022f0c0)
+	/home/vladimir/DEV/ktop/k8s/nodes_controller.go:106 +0x28 fp=0x40ab91bf20 sp=0x40ab91bee0 pc=0x1fc7778
+github.com/vladimirvivien/ktop/k8s.(*Controller).setupNodeHandler.func1()
+	/home/vladimir/DEV/ktop/k8s/nodes_controller.go:89 +0x40 fp=0x40ab91bfd0 sp=0x40ab91bf20 pc=0x1fc7610
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40ab91bfd0 sp=0x40ab91bfd0 pc=0xe857d4
+created by github.com/vladimirvivien/ktop/k8s.(*Controller).setupNodeHandler in goroutine 46
+	/home/vladimir/DEV/ktop/k8s/nodes_controller.go:88 +0x84
+
+goroutine 112 gp=0x4000513dc0 m=nil [chan receive]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x40000796b0 sp=0x4000079690 pc=0xe7da00
+runtime.chanrecv(0x40000b3110, 0x400007978f, 0x1)
+	/snap/go/10988/src/runtime/chan.go:667 +0x428 fp=0x4000079730 sp=0x40000796b0 pc=0xe13558
+runtime.chanrecv2(0x4000079778?, 0xa000b3101?)
+	/snap/go/10988/src/runtime/chan.go:514 +0x14 fp=0x4000079760 sp=0x4000079730 pc=0xe13114
+github.com/vladimirvivien/ktop/application.(*Application).Run.func1()
+	/home/vladimir/DEV/ktop/application/app_ctrl.go:169 +0x78 fp=0x40000797d0 sp=0x4000079760 pc=0x1fcb398
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40000797d0 sp=0x40000797d0 pc=0xe857d4
+created by github.com/vladimirvivien/ktop/application.(*Application).Run in goroutine 46
+	/home/vladimir/DEV/ktop/application/app_ctrl.go:168 +0x6c
+
+goroutine 97 gp=0x400016aa80 m=nil [select]:
+runtime.gopark(0x4000079f70?, 0x2?, 0xf4?, 0x1?, 0x4000079f4c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000079dc0 sp=0x4000079da0 pc=0xe7da00
+runtime.selectgo(0x4000079f70, 0x4000079f48, 0x0?, 0x0, 0x4000079f60?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000079f00 sp=0x4000079dc0 pc=0xe5c11c
+github.com/gdamore/tcell/v2.(*devTty).Start.func1(0x4000508150)
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tty_unix.go:93 +0x8c fp=0x4000079fb0 sp=0x4000079f00 pc=0x106480c
+github.com/gdamore/tcell/v2.(*devTty).Start.gowrap2()
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tty_unix.go:105 +0x2c fp=0x4000079fd0 sp=0x4000079fb0 pc=0x106474c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000079fd0 sp=0x4000079fd0 pc=0xe857d4
+created by github.com/gdamore/tcell/v2.(*devTty).Start in goroutine 46
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tty_unix.go:90 +0x214
+
+goroutine 162 gp=0x400016ac40 m=nil [select, locked to thread]:
+runtime.gopark(0x40007837a0?, 0x2?, 0x98?, 0x36?, 0x400078378c?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000783600 sp=0x40007835e0 pc=0xe7da00
+runtime.selectgo(0x40007837a0, 0x4000783788, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000783740 sp=0x4000783600 pc=0xe5c11c
+runtime.ensureSigM.func1()
+	/snap/go/10988/src/runtime/signal_unix.go:1085 +0x188 fp=0x40007837d0 sp=0x4000783740 pc=0xe77968
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40007837d0 sp=0x40007837d0 pc=0xe857d4
+created by runtime.ensureSigM in goroutine 46
+	/snap/go/10988/src/runtime/signal_unix.go:1068 +0xcc
+
+goroutine 163 gp=0x400016ae00 m=4 mp=0x4000081808 [syscall]:
+runtime.notetsleepg(0x37375e0, 0xffffffffffffffff)
+	/snap/go/10988/src/runtime/lock_futex.go:123 +0x34 fp=0x4000783f90 sp=0x4000783f60 pc=0xe18624
+os/signal.signal_recv()
+	/snap/go/10988/src/runtime/sigqueue.go:152 +0x30 fp=0x4000783fb0 sp=0x4000783f90 pc=0xe7fb60
+os/signal.loop()
+	/snap/go/10988/src/os/signal/signal_unix.go:23 +0x1c fp=0x4000783fd0 sp=0x4000783fb0 pc=0x103e46c
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000783fd0 sp=0x4000783fd0 pc=0xe857d4
+created by os/signal.Notify.func1.1 in goroutine 46
+	/snap/go/10988/src/os/signal/signal.go:152 +0x28
+
+goroutine 164 gp=0x400016afc0 m=0 mp=0x370f520 [syscall]:
+syscall.Syscall(0x3f, 0x7, 0x4000614200, 0x80)
+	/snap/go/10988/src/syscall/syscall_linux.go:74 +0x20 fp=0x40007845a0 sp=0x4000784540 pc=0xee0c80
+syscall.read(0x400028fb60?, {0x4000614200?, 0x1?, 0x0?})
+	/snap/go/10988/src/syscall/zsyscall_linux_arm64.go:736 +0x40 fp=0x40007845e0 sp=0x40007845a0 pc=0xedf000
+syscall.Read(...)
+	/snap/go/10988/src/syscall/syscall_unix.go:183
+internal/poll.ignoringEINTRIO(...)
+	/snap/go/10988/src/internal/poll/fd_unix.go:738
+internal/poll.(*FD).Read(0x400028fb60, {0x4000614200, 0x80, 0x80})
+	/snap/go/10988/src/internal/poll/fd_unix.go:161 +0x204 fp=0x4000784680 sp=0x40007845e0 pc=0xf00114
+os.(*File).read(...)
+	/snap/go/10988/src/os/file_posix.go:29
+os.(*File).Read(0x400040c048, {0x4000614200?, 0x1?, 0x0?})
+	/snap/go/10988/src/os/file.go:144 +0x68 fp=0x40007846c0 sp=0x4000784680 pc=0xf0a9a8
+github.com/gdamore/tcell/v2.(*devTty).Read(0x0?, {0x4000614200?, 0x0?, 0x0?})
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tty_unix.go:47 +0x24 fp=0x40007846f0 sp=0x40007846c0 pc=0x1064314
+github.com/gdamore/tcell/v2.(*tScreen).inputLoop(0x40004ea248, 0x4000508310)
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1546 +0xa0 fp=0x40007847b0 sp=0x40007846f0 pc=0x10630b0
+github.com/gdamore/tcell/v2.(*tScreen).engage.gowrap2()
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1680 +0x28 fp=0x40007847d0 sp=0x40007847b0 pc=0x1063e48
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x40007847d0 sp=0x40007847d0 pc=0xe857d4
+created by github.com/gdamore/tcell/v2.(*tScreen).engage in goroutine 46
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1680 +0x270
+
+goroutine 165 gp=0x400016b180 m=nil [select]:
+runtime.gopark(0x4000784ef0?, 0x5?, 0x0?, 0x0?, 0x4000784ec6?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x4000784d40 sp=0x4000784d20 pc=0xe7da00
+runtime.selectgo(0x4000784ef0, 0x4000784ebc, 0x0?, 0x0, 0x0?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x4000784e80 sp=0x4000784d40 pc=0xe5c11c
+github.com/gdamore/tcell/v2.(*tScreen).mainLoop(0x40004ea248, 0x4000508310)
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1485 +0xcc fp=0x4000784fb0 sp=0x4000784e80 pc=0x1062c0c
+github.com/gdamore/tcell/v2.(*tScreen).engage.gowrap3()
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1681 +0x28 fp=0x4000784fd0 sp=0x4000784fb0 pc=0x1063de8
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x4000784fd0 sp=0x4000784fd0 pc=0xe857d4
+created by github.com/gdamore/tcell/v2.(*tScreen).engage in goroutine 46
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:1681 +0x2b8
+
+goroutine 113 gp=0x4000550000 m=nil [select]:
+runtime.gopark(0x400012df08?, 0x2?, 0x8?, 0xde?, 0x400012df04?)
+	/snap/go/10988/src/runtime/proc.go:460 +0xc0 fp=0x400012dd80 sp=0x400012dd60 pc=0xe7da00
+runtime.selectgo(0x400012df08, 0x400012df00, 0x0?, 0x0, 0x400028aae8?, 0x1)
+	/snap/go/10988/src/runtime/select.go:351 +0x6bc fp=0x400012dec0 sp=0x400012dd80 pc=0xe5c11c
+github.com/gdamore/tcell/v2.(*tScreen).PollEvent(0x0?)
+	/home/vladimir/go/pkg/mod/github.com/gdamore/tcell/v2@v2.4.1-0.20210905002822-f057f0a857a1/tscreen.go:965 +0x54 fp=0x400012df40 sp=0x400012dec0 pc=0x1061034
+github.com/rivo/tview.(*Application).Run.func2()
+	/home/vladimir/go/pkg/mod/github.com/rivo/tview@v0.0.0-20211202162923-2a6de950f73b/application.go:267 +0x11c fp=0x400012dfd0 sp=0x400012df40 pc=0x1067cdc
+runtime.goexit({})
+	/snap/go/10988/src/runtime/asm_arm64.s:1268 +0x4 fp=0x400012dfd0 sp=0x400012dfd0 pc=0xe857d4
+created by github.com/rivo/tview.(*Application).Run in goroutine 46
+	/home/vladimir/go/pkg/mod/github.com/rivo/tview@v0.0.0-20211202162923-2a6de950f73b/application.go:254 +0x130

--- a/prom/controller_test.go
+++ b/prom/controller_test.go
@@ -271,7 +271,7 @@ func TestQueryMetricRange(t *testing.T) {
 		store.AddMetrics(testMetrics)
 
 		// Query range
-		samples, err := controller.QueryMetricRange("test_gauge", 
+		samples, err := controller.QueryMetricRange("test_gauge",
 			map[string]string{"instance": "localhost:8080"}, 5*time.Minute)
 		if err != nil {
 			t.Errorf("Failed to query metric range: %v", err)
@@ -365,7 +365,7 @@ func TestControllerWithMockCollector(t *testing.T) {
 	collected := metricsCollectedCount
 	errors := errorCount
 	mu.Unlock()
-	
+
 	t.Logf("Metrics collected: %d, Errors: %d", collected, errors)
 }
 
@@ -390,7 +390,7 @@ func (m *MockCollector) ScrapeComponent(ctx context.Context, component Component
 	if !m.started {
 		return nil, ErrCollectorNotStarted
 	}
-	
+
 	// Return test metrics
 	metrics := *m.metrics // Copy
 	metrics.Component = component
@@ -411,7 +411,7 @@ var ErrCollectorNotStarted = fmt.Errorf("collector not started")
 func TestControllerDiscovery(t *testing.T) {
 	kubeConfig := &rest.Config{Host: "https://test-cluster"}
 	config := DefaultScrapeConfig()
-	
+
 	controller := NewCollectorController(kubeConfig, config)
 
 	// Initialize the controller to set up the collector
@@ -453,6 +453,6 @@ func TestControllerErrorHandling(t *testing.T) {
 	// The controller should handle errors gracefully
 	// We can check that error callbacks were called if errors occurred
 	// But we don't require errors for the test to pass
-	_ = err // Use the variable
+	_ = err        // Use the variable
 	_ = errorCount // Use the variable
 }

--- a/prom/example_usage.go
+++ b/prom/example_usage.go
@@ -17,35 +17,35 @@ func ExampleUsage() {
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %v", err)
 	}
-	
+
 	// 2. Create Prometheus integration
 	integration := NewIntegration(kubeConfig, true)
 	if !integration.IsEnabled() {
 		log.Println("Prometheus integration is disabled")
 		return
 	}
-	
+
 	// 3. Start metrics collection
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
+
 	if err := integration.Start(ctx); err != nil {
 		log.Fatalf("Error starting Prometheus integration: %v", err)
 	}
-	
+
 	// 4. Wait for initial metrics collection
 	time.Sleep(5 * time.Second)
-	
+
 	// 5. Query some metrics
 	demonstrateMetricQueries(integration)
-	
+
 	// 6. Show cluster summary
 	demonstrateClusterSummary(integration)
 }
 
 func demonstrateMetricQueries(integration *Integration) {
 	fmt.Println("=== Prometheus Metrics Queries ===")
-	
+
 	// Get node metrics for the first available node
 	if nodes := integration.GetAvailableComponents(); len(nodes) > 0 {
 		// This would require node discovery, simplified for example
@@ -58,7 +58,7 @@ func demonstrateMetricQueries(integration *Integration) {
 			fmt.Printf("Node Network RX: %.2f bytes\n", nodeMetrics.NetworkRxBytesTotal)
 		}
 	}
-	
+
 	// Get pod metrics for a sample pod
 	podMetrics, err := integration.GetPodMetrics("kube-system", "coredns-1234") // Example pod
 	if err != nil {
@@ -72,15 +72,15 @@ func demonstrateMetricQueries(integration *Integration) {
 
 func demonstrateClusterSummary(integration *Integration) {
 	fmt.Println("\n=== Cluster Summary ===")
-	
+
 	summary := integration.GetClusterSummary()
 	for key, value := range summary {
 		fmt.Printf("%s: %v\n", key, value)
 	}
-	
+
 	fmt.Printf("Available components: %v\n", integration.GetAvailableComponents())
 	fmt.Printf("Integration healthy: %v\n", integration.IsHealthy())
-	
+
 	if err := integration.GetLastError(); err != nil {
 		fmt.Printf("Last error: %v\n", err)
 	}
@@ -89,22 +89,22 @@ func demonstrateClusterSummary(integration *Integration) {
 // ExampleRESTClientUsage shows the internal RESTClient usage patterns
 func ExampleRESTClientUsage(kubeConfig *rest.Config) {
 	fmt.Println("=== RESTClient Usage Examples ===")
-	
+
 	// This demonstrates the patterns used internally by the scraper
 	config := DefaultScrapeConfig()
 	scraper, err := NewKubernetesScraper(kubeConfig, config)
 	if err != nil {
 		log.Fatalf("Error creating scraper: %v", err)
 	}
-	
+
 	ctx := context.Background()
-	
+
 	// Discover targets using RESTClient-based discovery
 	if err := scraper.discoverTargets(ctx); err != nil {
 		log.Printf("Error discovering targets: %v", err)
 		return
 	}
-	
+
 	// Show discovered targets
 	for component, targets := range scraper.targets {
 		fmt.Printf("Component %s: %d targets\n", component, len(targets))
@@ -124,20 +124,20 @@ func ExampleRESTClientUsage(kubeConfig *rest.Config) {
 // ExampleIntegrationWithKtop shows how ktop controllers would use this
 func ExampleIntegrationWithKtop(kubeConfig *rest.Config) {
 	fmt.Println("=== Integration with ktop ===")
-	
+
 	// 1. Initialize Prometheus integration
 	promIntegration := NewIntegration(kubeConfig, true)
-	
+
 	// 2. Start in background
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
+
 	go func() {
 		if err := promIntegration.Start(ctx); err != nil {
 			log.Printf("Prometheus integration error: %v", err)
 		}
 	}()
-	
+
 	// 3. Use in existing ktop refresh functions
 	// This would be called from k8s/client_controller.go
 	refreshNodeViewWithPrometheus := func(nodeName string) {
@@ -148,17 +148,17 @@ func ExampleIntegrationWithKtop(kubeConfig *rest.Config) {
 				fmt.Printf("Enhanced metrics for %s:\n", nodeName)
 				fmt.Printf("  CPU Cores Usage: %v\n", nodeMetrics.CPUUsageByCore)
 				fmt.Printf("  Load Average: %v\n", nodeMetrics.CPULoadAverage)
-				fmt.Printf("  Network I/O: RX=%.0f, TX=%.0f\n", 
+				fmt.Printf("  Network I/O: RX=%.0f, TX=%.0f\n",
 					nodeMetrics.NetworkRxBytesTotal, nodeMetrics.NetworkTxBytesTotal)
 				fmt.Printf("  Disk I/O: Read=%.0f, Write=%.0f\n",
 					nodeMetrics.DiskReadBytesTotal, nodeMetrics.DiskWriteBytesTotal)
 			}
 		}
-		
+
 		// Fall back to regular metrics-server data if Prometheus not available
 		fmt.Printf("Using fallback metrics for %s\n", nodeName)
 	}
-	
+
 	// Example usage
 	refreshNodeViewWithPrometheus("worker-node-1")
 }

--- a/prom/integration.go
+++ b/prom/integration.go
@@ -18,15 +18,15 @@ func NewIntegration(kubeConfig *rest.Config, enabled bool) *Integration {
 	if !enabled {
 		return &Integration{enabled: false}
 	}
-	
+
 	config := DefaultScrapeConfig()
 	// Use shorter intervals for responsive UI
 	config.Interval = 15 * time.Second
 	config.RetentionTime = 30 * time.Minute
 	config.MaxSamples = 500
-	
+
 	controller := NewCollectorController(kubeConfig, config)
-	
+
 	return &Integration{
 		controller: controller,
 		enabled:    true,
@@ -43,7 +43,7 @@ func (i *Integration) Start(ctx context.Context) error {
 	if !i.enabled {
 		return nil
 	}
-	
+
 	return i.controller.Start(ctx)
 }
 
@@ -52,7 +52,7 @@ func (i *Integration) Stop() error {
 	if !i.enabled {
 		return nil
 	}
-	
+
 	return i.controller.Stop()
 }
 
@@ -63,58 +63,58 @@ type NodeMetrics struct {
 	CPUUsageByCore     map[string]float64
 	CPUThrottlePercent float64
 	CPULoadAverage     [3]float64
-	
+
 	// Memory metrics
 	MemoryUsageBytes     int64
 	MemoryUsagePercent   float64
 	MemoryAvailableBytes int64
 	MemoryCachedBytes    int64
 	MemoryBuffersBytes   int64
-	
+
 	// Network metrics
 	NetworkRxBytesTotal float64
 	NetworkTxBytesTotal float64
 	NetworkRxErrors     float64
 	NetworkTxErrors     float64
-	
+
 	// Disk metrics
 	DiskReadBytesTotal  float64
 	DiskWriteBytesTotal float64
 	DiskIOUtilization   float64
-	
+
 	// System metrics
-	ProcessCount    int64
-	ProcessRunning  int64
-	ProcessBlocked  int64
-	UptimeSeconds   float64
+	ProcessCount   int64
+	ProcessRunning int64
+	ProcessBlocked int64
+	UptimeSeconds  float64
 }
 
 // PodMetrics represents enhanced metrics for a pod
 type PodMetrics struct {
 	// Container-level CPU metrics
-	CPUUsagePercent   float64
-	CPUThrottleCount  float64
+	CPUUsagePercent    float64
+	CPUThrottleCount   float64
 	CPUThrottlePercent float64
-	
+
 	// Container-level Memory metrics
-	MemoryUsageBytes    int64
-	MemoryRSSBytes      int64
+	MemoryUsageBytes      int64
+	MemoryRSSBytes        int64
 	MemoryWorkingSetBytes int64
-	MemoryLimitBytes    int64
-	
+	MemoryLimitBytes      int64
+
 	// Network metrics (if available)
 	NetworkRxBytes float64
 	NetworkTxBytes float64
-	
+
 	// Filesystem metrics
 	FilesystemUsageBytes     int64
 	FilesystemAvailableBytes int64
 	FilesystemCapacityBytes  int64
-	
+
 	// Container state
-	RestartCount     int64
-	OOMKillCount     int64
-	LastSeenRunning  time.Time
+	RestartCount    int64
+	OOMKillCount    int64
+	LastSeenRunning time.Time
 }
 
 // GetNodeMetrics retrieves enhanced metrics for a specific node
@@ -122,43 +122,43 @@ func (i *Integration) GetNodeMetrics(nodeName string) (*NodeMetrics, error) {
 	if !i.enabled || !i.controller.IsRunning() {
 		return nil, nil
 	}
-	
+
 	metrics := &NodeMetrics{}
-	
+
 	// CPU Usage - from cAdvisor or kubelet
-	if cpuUsage, err := i.controller.QueryMetric("node_cpu_usage_seconds_total", 
+	if cpuUsage, err := i.controller.QueryMetric("node_cpu_usage_seconds_total",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.CPUUsagePercent = cpuUsage
 	}
-	
+
 	// Memory Usage - from node_exporter or kubelet
 	if memUsage, err := i.controller.QueryMetric("node_memory_MemAvailable_bytes",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.MemoryAvailableBytes = int64(memUsage)
 	}
-	
+
 	// Network metrics
 	if netRx, err := i.controller.QueryMetric("node_network_receive_bytes_total",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.NetworkRxBytesTotal = netRx
 	}
-	
+
 	if netTx, err := i.controller.QueryMetric("node_network_transmit_bytes_total",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.NetworkTxBytesTotal = netTx
 	}
-	
+
 	// Disk I/O metrics
 	if diskRead, err := i.controller.QueryMetric("node_disk_read_bytes_total",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.DiskReadBytesTotal = diskRead
 	}
-	
+
 	if diskWrite, err := i.controller.QueryMetric("node_disk_written_bytes_total",
 		map[string]string{"instance": "*" + nodeName + "*"}); err == nil {
 		metrics.DiskWriteBytesTotal = diskWrite
 	}
-	
+
 	return metrics, nil
 }
 
@@ -167,49 +167,49 @@ func (i *Integration) GetPodMetrics(namespace, podName string) (*PodMetrics, err
 	if !i.enabled || !i.controller.IsRunning() {
 		return nil, nil
 	}
-	
+
 	metrics := &PodMetrics{}
-	
+
 	// CPU metrics from cAdvisor
 	if cpuUsage, err := i.controller.QueryMetric("container_cpu_usage_seconds_total",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.CPUUsagePercent = cpuUsage
 	}
-	
+
 	// Memory metrics from cAdvisor
 	if memUsage, err := i.controller.QueryMetric("container_memory_usage_bytes",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.MemoryUsageBytes = int64(memUsage)
 	}
-	
+
 	if memWorkingSet, err := i.controller.QueryMetric("container_memory_working_set_bytes",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.MemoryWorkingSetBytes = int64(memWorkingSet)
 	}
-	
+
 	// Network metrics
 	if netRx, err := i.controller.QueryMetric("container_network_receive_bytes_total",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.NetworkRxBytes = netRx
 	}
-	
+
 	if netTx, err := i.controller.QueryMetric("container_network_transmit_bytes_total",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.NetworkTxBytes = netTx
 	}
-	
+
 	// Filesystem metrics
 	if fsUsage, err := i.controller.QueryMetric("container_fs_usage_bytes",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.FilesystemUsageBytes = int64(fsUsage)
 	}
-	
+
 	// Restart count
 	if restarts, err := i.controller.QueryMetric("kube_pod_container_status_restarts_total",
 		map[string]string{"namespace": namespace, "pod": podName}); err == nil {
 		metrics.RestartCount = int64(restarts)
 	}
-	
+
 	return metrics, nil
 }
 
@@ -220,23 +220,23 @@ func (i *Integration) GetClusterSummary() map[string]interface{} {
 			"prometheus_enabled": false,
 		}
 	}
-	
+
 	summary := map[string]interface{}{
 		"prometheus_enabled": true,
 	}
-	
+
 	// Add controller stats
 	if stats := i.controller.GetStats(); stats != nil {
 		summary["controller_stats"] = stats
 	}
-	
+
 	// Add available metrics count
 	if store := i.controller.GetStore(); store != nil {
 		metricNames := store.GetMetricNames()
 		summary["total_metrics"] = len(metricNames)
 		summary["sample_metric_names"] = metricNames[:minInt(10, len(metricNames))]
 	}
-	
+
 	return summary
 }
 
@@ -245,13 +245,13 @@ func (i *Integration) GetAvailableComponents() []string {
 	if !i.enabled {
 		return []string{}
 	}
-	
+
 	components := i.controller.GetAvailableComponents()
 	result := make([]string, len(components))
 	for i, comp := range components {
 		result[i] = string(comp)
 	}
-	
+
 	return result
 }
 
@@ -260,21 +260,21 @@ func (i *Integration) GetNodeTrends(nodeName string, duration time.Duration) map
 	if !i.enabled || !i.controller.IsRunning() {
 		return nil
 	}
-	
+
 	trends := make(map[string][]*MetricSample)
-	
+
 	// CPU trend
 	if samples, err := i.controller.QueryMetricRange("node_cpu_usage_seconds_total",
 		map[string]string{"instance": "*" + nodeName + "*"}, duration); err == nil {
 		trends["cpu"] = samples
 	}
-	
+
 	// Memory trend
 	if samples, err := i.controller.QueryMetricRange("node_memory_MemAvailable_bytes",
 		map[string]string{"instance": "*" + nodeName + "*"}, duration); err == nil {
 		trends["memory"] = samples
 	}
-	
+
 	return trends
 }
 
@@ -283,7 +283,7 @@ func (i *Integration) IsHealthy() bool {
 	if !i.enabled {
 		return true // Not enabled is considered "healthy"
 	}
-	
+
 	return i.controller.IsRunning() && i.controller.GetLastError() == nil
 }
 
@@ -292,7 +292,7 @@ func (i *Integration) GetLastError() error {
 	if !i.enabled {
 		return nil
 	}
-	
+
 	return i.controller.GetLastError()
 }
 

--- a/prom/scraper_test.go
+++ b/prom/scraper_test.go
@@ -39,7 +39,7 @@ func TestNewKubernetesScraper(t *testing.T) {
 func TestDiscoverAPIServerTargets(t *testing.T) {
 	config := &rest.Config{Host: "https://test-cluster"}
 	scrapeConfig := DefaultScrapeConfig()
-	
+
 	scraper, err := NewKubernetesScraper(config, scrapeConfig)
 	if err != nil {
 		t.Fatalf("Failed to create scraper: %v", err)
@@ -77,7 +77,7 @@ func TestDiscoverAPIServerTargets(t *testing.T) {
 func TestDiscoverNodeTargets(t *testing.T) {
 	// Create fake Kubernetes client with test nodes
 	fakeClient := fake.NewSimpleClientset()
-	
+
 	// Add test nodes
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
@@ -87,7 +87,7 @@ func TestDiscoverNodeTargets(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
 		Status:     corev1.NodeStatus{Phase: corev1.NodeRunning},
 	}
-	
+
 	fakeClient.CoreV1().Nodes().Create(context.Background(), node1, metav1.CreateOptions{})
 	fakeClient.CoreV1().Nodes().Create(context.Background(), node2, metav1.CreateOptions{})
 
@@ -148,7 +148,7 @@ func TestDiscoverNodeTargets(t *testing.T) {
 func TestDiscoverPodTargets(t *testing.T) {
 	// Create fake Kubernetes client with test pods
 	fakeClient := fake.NewSimpleClientset()
-	
+
 	// Add test pods for different components
 	etcdPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -158,7 +158,7 @@ func TestDiscoverPodTargets(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	
+
 	schedulerPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-scheduler-master",
@@ -167,7 +167,7 @@ func TestDiscoverPodTargets(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	
+
 	fakeClient.CoreV1().Pods("kube-system").Create(context.Background(), etcdPod, metav1.CreateOptions{})
 	fakeClient.CoreV1().Pods("kube-system").Create(context.Background(), schedulerPod, metav1.CreateOptions{})
 
@@ -230,7 +230,7 @@ func TestDiscoverPodTargets(t *testing.T) {
 
 func TestParseMetricsBody(t *testing.T) {
 	scraper := &KubernetesScraper{}
-	
+
 	// Sample Prometheus metrics data
 	metricsData := `# HELP test_counter_total A test counter metric
 # TYPE test_counter_total counter
@@ -282,12 +282,12 @@ test_gauge{label="test"} 3.14
 
 func TestConvertMetricFamily(t *testing.T) {
 	scraper := &KubernetesScraper{}
-	
+
 	// Create a test DTO metric family
 	metricName := "test_metric"
 	help := "A test metric"
 	metricType := dto.MetricType_GAUGE
-	
+
 	dtoFamily := &dto.MetricFamily{
 		Name: &metricName,
 		Help: &help,
@@ -332,7 +332,7 @@ func TestConvertMetricFamily(t *testing.T) {
 	}
 
 	timeSeries := internalFamily.TimeSeries[0]
-	
+
 	// Check labels (should include __name__ + metric labels)
 	expectedLabels := 3 // __name__, instance, job
 	if len(timeSeries.Labels) != expectedLabels {
@@ -359,14 +359,14 @@ func TestConvertMetricFamily(t *testing.T) {
 func TestGetAvailableComponents(t *testing.T) {
 	// Create fake client with test resources
 	fakeClient := fake.NewSimpleClientset()
-	
+
 	// Add a node for kubelet/cAdvisor
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
 		Status:     corev1.NodeStatus{Phase: corev1.NodeRunning},
 	}
 	fakeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
-	
+
 	// Add an etcd pod
 	etcdPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/prom/storage_test.go
+++ b/prom/storage_test.go
@@ -78,7 +78,7 @@ func TestAddMetrics(t *testing.T) {
 func TestQueryLatest(t *testing.T) {
 	store := NewInMemoryStore(DefaultScrapeConfig())
 	metrics := createTestScrapedMetrics()
-	
+
 	err := store.AddMetrics(metrics)
 	if err != nil {
 		t.Fatalf("Failed to add metrics: %v", err)
@@ -114,14 +114,14 @@ func TestQueryRange(t *testing.T) {
 	// Add metrics at different times
 	now := time.Now()
 	for i := 0; i < 5; i++ {
-		metrics := createTestScrapedMetricsAtTime(now.Add(time.Duration(i)*time.Minute))
+		metrics := createTestScrapedMetricsAtTime(now.Add(time.Duration(i) * time.Minute))
 		store.AddMetrics(metrics)
 	}
 
 	// Query range
 	start := now.Add(-1 * time.Minute)
 	end := now.Add(6 * time.Minute)
-	
+
 	samples, err := store.QueryRange("test_gauge", map[string]string{"instance": "localhost:8080"}, start, end)
 	if err != nil {
 		t.Fatalf("Failed to query range: %v", err)
@@ -152,7 +152,7 @@ func TestMaxSamplesLimit(t *testing.T) {
 	// Add 5 samples (more than the limit of 3)
 	for i := 0; i < 5; i++ {
 		timeSeries.Samples = append(timeSeries.Samples, MetricSample{
-			Timestamp: time.Now().Add(time.Duration(i)*time.Second).UnixMilli(),
+			Timestamp: time.Now().Add(time.Duration(i) * time.Second).UnixMilli(),
 			Value:     float64(i),
 		})
 	}
@@ -204,7 +204,7 @@ func TestCleanup(t *testing.T) {
 func TestGetLabelValues(t *testing.T) {
 	store := NewInMemoryStore(DefaultScrapeConfig())
 	metrics := createTestScrapedMetrics()
-	
+
 	err := store.AddMetrics(metrics)
 	if err != nil {
 		t.Fatalf("Failed to add metrics: %v", err)
@@ -238,7 +238,7 @@ func TestGetLabelValues(t *testing.T) {
 func TestGetStats(t *testing.T) {
 	store := NewInMemoryStore(DefaultScrapeConfig())
 	metrics := createTestScrapedMetrics()
-	
+
 	err := store.AddMetrics(metrics)
 	if err != nil {
 		t.Fatalf("Failed to add metrics: %v", err)

--- a/prom/types.go
+++ b/prom/types.go
@@ -14,13 +14,13 @@ import (
 type ComponentType string
 
 const (
-	ComponentAPIServer          ComponentType = "apiserver"
-	ComponentKubelet            ComponentType = "kubelet"
-	ComponentCAdvisor           ComponentType = "cadvisor"
-	ComponentEtcd               ComponentType = "etcd"
-	ComponentScheduler          ComponentType = "scheduler"
-	ComponentControllerManager  ComponentType = "controller-manager"
-	ComponentKubeProxy          ComponentType = "kube-proxy"
+	ComponentAPIServer         ComponentType = "apiserver"
+	ComponentKubelet           ComponentType = "kubelet"
+	ComponentCAdvisor          ComponentType = "cadvisor"
+	ComponentEtcd              ComponentType = "etcd"
+	ComponentScheduler         ComponentType = "scheduler"
+	ComponentControllerManager ComponentType = "controller-manager"
+	ComponentKubeProxy         ComponentType = "kube-proxy"
 )
 
 // MetricSample represents a single metric data point
@@ -46,12 +46,12 @@ type MetricFamily struct {
 
 // ScrapedMetrics represents metrics collected from a single component
 type ScrapedMetrics struct {
-	Component   ComponentType
-	Endpoint    string
-	Families    map[string]*MetricFamily
-	ScrapedAt   time.Time
+	Component      ComponentType
+	Endpoint       string
+	Families       map[string]*MetricFamily
+	ScrapedAt      time.Time
 	ScrapeDuration time.Duration
-	Error       error
+	Error          error
 }
 
 // ScrapeTarget represents a component endpoint to scrape
@@ -67,28 +67,28 @@ type ScrapeTarget struct {
 
 // ScrapeConfig holds configuration for the metrics scraper
 type ScrapeConfig struct {
-	Interval       time.Duration
-	Timeout        time.Duration
-	MaxSamples     int // Maximum samples per time series
-	RetentionTime  time.Duration
-	InsecureTLS    bool
-	Components     []ComponentType // Components to scrape
+	Interval      time.Duration
+	Timeout       time.Duration
+	MaxSamples    int // Maximum samples per time series
+	RetentionTime time.Duration
+	InsecureTLS   bool
+	Components    []ComponentType // Components to scrape
 }
 
 // MetricsCollector defines the interface for collecting metrics
 type MetricsCollector interface {
 	// Start begins the metrics collection process
 	Start(ctx context.Context) error
-	
+
 	// Stop gracefully stops the metrics collection
 	Stop() error
-	
+
 	// ScrapeComponent manually triggers a scrape for a specific component
 	ScrapeComponent(ctx context.Context, component ComponentType) (*ScrapedMetrics, error)
-	
+
 	// GetLastScrape returns the last scrape result for a component
 	GetLastScrape(component ComponentType) (*ScrapedMetrics, error)
-	
+
 	// GetAvailableComponents returns list of available components to scrape
 	GetAvailableComponents(ctx context.Context) ([]ComponentType, error)
 }
@@ -97,41 +97,41 @@ type MetricsCollector interface {
 type MetricsStore interface {
 	// AddMetrics stores scraped metrics
 	AddMetrics(metrics *ScrapedMetrics) error
-	
+
 	// QueryLatest returns the latest value for a metric
 	QueryLatest(metricName string, labelMatchers map[string]string) (float64, error)
-	
+
 	// QueryRange returns metric values over a time range
 	QueryRange(metricName string, labelMatchers map[string]string, start, end time.Time) ([]*MetricSample, error)
-	
+
 	// GetMetricNames returns all available metric names
 	GetMetricNames() []string
-	
+
 	// GetLabelValues returns all values for a given label name
 	GetLabelValues(labelName string) []string
-	
+
 	// Cleanup removes old metrics based on retention policy
 	Cleanup() error
 }
 
 // CollectorController manages the overall metrics collection process
 type CollectorController struct {
-	mutex     sync.RWMutex
-	config    *ScrapeConfig
-	collector MetricsCollector
-	store     MetricsStore
+	mutex      sync.RWMutex
+	config     *ScrapeConfig
+	collector  MetricsCollector
+	store      MetricsStore
 	kubeConfig *rest.Config
-	
+
 	// State tracking
 	running   bool
 	lastError error
-	
+
 	// Component availability
 	availableComponents map[ComponentType]bool
-	
+
 	// Event callbacks
 	onMetricsCollected func(component ComponentType, metrics *ScrapedMetrics)
-	onError           func(component ComponentType, err error)
+	onError            func(component ComponentType, err error)
 }
 
 // DefaultScrapeConfig returns a default configuration for metrics scraping
@@ -155,7 +155,7 @@ func NewCollectorController(kubeConfig *rest.Config, config *ScrapeConfig) *Coll
 	if config == nil {
 		config = DefaultScrapeConfig()
 	}
-	
+
 	return &CollectorController{
 		config:              config,
 		kubeConfig:          kubeConfig,
@@ -195,7 +195,7 @@ func (cc *CollectorController) GetLastError() error {
 func (cc *CollectorController) GetAvailableComponents() []ComponentType {
 	cc.mutex.RLock()
 	defer cc.mutex.RUnlock()
-	
+
 	var components []ComponentType
 	for component, available := range cc.availableComponents {
 		if available {

--- a/ui/format.go
+++ b/ui/format.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// FormatMemory formats a memory quantity in the most appropriate unit (Mi or Gi)
+// Uses Gi only when >= 10Gi to match kubectl behavior, otherwise uses Mi
+func FormatMemory(qty *resource.Quantity) string {
+	if qty == nil {
+		return "0Mi"
+	}
+
+	bytes := qty.Value()
+	if bytes == 0 {
+		return "0Mi"
+	}
+
+	// Calculate Mi (binary)
+	mi := bytes / (1024 * 1024)
+
+	// Only use Gi for very large values (>= 10240 Mi = 10 Gi)
+	// This matches kubectl's behavior of preferring Mi for smaller values
+	if mi >= 10240 {
+		gi := bytes / (1024 * 1024 * 1024)
+		return fmt.Sprintf("%dGi", gi)
+	}
+
+	// Display in Mi for everything else
+	return fmt.Sprintf("%dMi", mi)
+}

--- a/ui/format_test.go
+++ b/ui/format_test.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestFormatMemory(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "nil quantity",
+			input:    "",
+			expected: "0Mi",
+		},
+		{
+			name:     "zero bytes",
+			input:    "0",
+			expected: "0Mi",
+		},
+		{
+			name:     "small value in Mi",
+			input:    "56Mi",
+			expected: "56Mi",
+		},
+		{
+			name:     "medium value in Mi",
+			input:    "366Mi",
+			expected: "366Mi",
+		},
+		{
+			name:     "large value in Mi",
+			input:    "512Mi",
+			expected: "512Mi",
+		},
+		{
+			name:     "exactly 1Gi",
+			input:    "1Gi",
+			expected: "1024Mi",
+		},
+		{
+			name:     "1024Mi should stay as Mi",
+			input:    "1024Mi",
+			expected: "1024Mi",
+		},
+		{
+			name:     "1404Mi should display as Mi",
+			input:    "1404Mi",
+			expected: "1404Mi",
+		},
+		{
+			name:     "2Gi should display as Mi",
+			input:    "2Gi",
+			expected: "2048Mi",
+		},
+		{
+			name:     "15Gi should display as Gi",
+			input:    "15Gi",
+			expected: "15Gi",
+		},
+		{
+			name:     "value in Ki should convert to Mi",
+			input:    "102400Ki", // 100Mi
+			expected: "100Mi",
+		},
+		{
+			name:     "value in bytes (1Gi)",
+			input:    "1073741824", // 1Gi in bytes
+			expected: "1024Mi",
+		},
+		{
+			name:     "value in bytes (20Gi)",
+			input:    "21474836480", // 20Gi in bytes
+			expected: "20Gi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var qty *resource.Quantity
+			if tt.input != "" {
+				q := resource.MustParse(tt.input)
+				qty = &q
+			}
+
+			result := FormatMemory(qty)
+			if result != tt.expected {
+				t.Errorf("FormatMemory(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/ui/icons.go
+++ b/ui/icons.go
@@ -17,8 +17,8 @@ var (
 		M               rune
 		Plane           rune
 		Controller      rune
-		Clock rune
-		TrafficLight rune
+		Clock           rune
+		TrafficLight    rune
 	}{
 		BargraphChar:    '|',
 		BargraphLBorder: '[',
@@ -35,7 +35,7 @@ var (
 		M:               'Ⓜ',
 		Plane:           '🛩',
 		Controller:      '🛂',
-		Clock: '⏰',
-		TrafficLight: '🚦',
+		Clock:           '⏰',
+		TrafficLight:    '🚦',
 	}
 )

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -56,23 +56,23 @@ func (p *MainPanel) Layout(data interface{}) {
 	// Define the default columns
 	allNodeColumns := []string{"NAME", "STATUS", "AGE", "VERSION", "INT/EXT IPs", "OS/ARC", "PODS/IMGs", "DISK", "CPU", "MEM"}
 	allPodColumns := []string{"NAMESPACE", "POD", "READY", "STATUS", "RESTARTS", "AGE", "VOLS", "IP", "NODE", "CPU", "MEMORY"}
-	
+
 	// Use filtered columns if specified
 	nodeColumnsToDisplay := allNodeColumns
 	podColumnsToDisplay := allPodColumns
-	
+
 	if !p.showAllColumns {
 		if len(p.nodeColumns) > 0 {
 			// Filter node columns
 			nodeColumnsToDisplay = filterColumns(allNodeColumns, p.nodeColumns)
 		}
-		
+
 		if len(p.podColumns) > 0 {
 			// Filter pod columns
 			podColumnsToDisplay = filterColumns(allPodColumns, p.podColumns)
 		}
 	}
-	
+
 	p.nodePanel = NewNodePanel(p.app, fmt.Sprintf(" %c Nodes ", ui.Icons.Factory))
 	p.nodePanel.DrawHeader(nodeColumnsToDisplay)
 
@@ -115,6 +115,7 @@ func (p *MainPanel) GetChildrenViews() []tview.Primitive {
 func (p *MainPanel) Run(ctx context.Context) error {
 	p.Layout(nil)
 	ctrl := p.app.GetK8sClient().Controller()
+	ctrl.SetMetricsSource(p.metricsSource) // Provide metrics source to controller for cluster summary
 	ctrl.SetClusterSummaryRefreshFunc(p.refreshWorkloadSummary)
 	ctrl.SetNodeRefreshFunc(p.refreshNodeView)
 	ctrl.SetPodRefreshFunc(p.refreshPods)

--- a/views/overview/pod_panel.go
+++ b/views/overview/pod_panel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/vladimirvivien/ktop/application"
 	"github.com/vladimirvivien/ktop/ui"
 	"github.com/vladimirvivien/ktop/views/model"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type podPanel struct {
@@ -65,7 +64,7 @@ func (p *podPanel) DrawHeader(data interface{}) {
 	// Initialize the column map
 	p.colMap = make(map[string]int)
 	p.listCols = cols
-	
+
 	// Set column headers and build column map
 	for i, col := range p.listCols {
 		p.list.SetCell(0, i,
@@ -76,7 +75,7 @@ func (p *podPanel) DrawHeader(data interface{}) {
 				SetExpansion(100).
 				SetSelectable(false),
 		)
-		
+
 		// Map column name to position
 		p.colMap[col] = i
 	}
@@ -99,14 +98,14 @@ func (p *podPanel) DrawBody(data interface{}) {
 
 	for rowIdx, pod := range pods {
 		rowIdx++ // offset for header row
-		
+
 		// Render each column that is included in the filtered view
 		for _, colName := range p.listCols {
 			colIdx, exists := p.colMap[colName]
 			if !exists {
 				continue
 			}
-			
+
 			switch colName {
 			case "NAMESPACE":
 				p.list.SetCell(
@@ -117,7 +116,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "POD":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -127,7 +126,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "READY":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -137,7 +136,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "STATUS":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -147,7 +146,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "RESTARTS":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -157,7 +156,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "AGE":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -167,7 +166,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "VOLS":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -177,7 +176,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "IP":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -187,7 +186,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "NODE":
 				p.list.SetCell(
 					rowIdx, colIdx,
@@ -197,7 +196,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "CPU":
 				// Check if we have actual usage metrics (non-zero values)
 				hasUsageMetrics := pod.PodUsageCpuQty != nil && pod.PodUsageCpuQty.MilliValue() > 0
@@ -237,7 +236,7 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Align: tview.AlignLeft,
 					},
 				)
-				
+
 			case "MEMORY":
 				// Check if we have actual usage metrics (non-zero values)
 				hasUsageMetrics := pod.PodUsageMemQty != nil && pod.PodUsageMemQty.Value() > 0
@@ -245,30 +244,30 @@ func (p *podPanel) DrawBody(data interface{}) {
 				hasAllocatable := pod.NodeAllocatableMemQty != nil && pod.NodeAllocatableMemQty.Value() > 0
 
 				if hasUsageMetrics && hasAllocatable {
-					// Display usage with graph: [||        ] 1Gi 0.5%
+					// Display usage with graph: [||        ] 366Mi 0.5%
 					memRatio = ui.GetRatio(float64(pod.PodUsageMemQty.Value()), float64(pod.NodeAllocatableMemQty.Value()))
 					memGraph = ui.BarGraph(10, memRatio, colorKeys)
 					memMetrics = fmt.Sprintf(
-						"[white][%s[white]] %dGi %.1f%%",
+						"[white][%s[white]] %s %.1f%%",
 						memGraph,
-						pod.PodUsageMemQty.ScaledValue(resource.Giga),
+						ui.FormatMemory(pod.PodUsageMemQty),
 						memRatio*100,
 					)
 				} else if hasRequestMetrics && hasAllocatable {
-					// Fallback: show requested with graph: [|         ] 1Gi 0.5%
+					// Fallback: show requested with graph: [|         ] 512Mi 0.5%
 					memRatio = ui.GetRatio(float64(pod.PodRequestedMemQty.Value()), float64(pod.NodeAllocatableMemQty.Value()))
 					memGraph = ui.BarGraph(10, memRatio, colorKeys)
 					memMetrics = fmt.Sprintf(
-						"[white][%s[white]] %dGi %.1f%%",
+						"[white][%s[white]] %s %.1f%%",
 						memGraph,
-						pod.PodRequestedMemQty.ScaledValue(resource.Giga),
+						ui.FormatMemory(pod.PodRequestedMemQty),
 						memRatio*100,
 					)
 				} else {
-					// Zero or unavailable: show empty graph with 0Gi 0.0%
+					// Zero or unavailable: show empty graph with 0Mi 0.0%
 					memGraph = ui.BarGraph(10, 0, colorKeys)
 					memMetrics = fmt.Sprintf(
-						"[white][%s[white]] 0Gi 0.0%%",
+						"[white][%s[white]] 0Mi 0.0%%",
 						memGraph,
 					)
 				}


### PR DESCRIPTION
This PR resolves critical bugs in metrics collection and display that were introduced after the MetricsSource integration.

  Startup Performance
  - Eliminated lag time startup delay by removing blocking metrics initialization
  - Refactor metrics informers and removed them from controller (now handled by MetricsSource interface)
  - Changed to non-blocking startup with async health checks and display updates

  Metrics Status
  - Fixed status showing "connected" when Metrics Server unavailable
  - Added periodic header refresh to update connection status in real-time
  - Status now reflects actual MetricsSource health, not cached API state

  Fixes
  - Created smart memory formatting helper that matches kubectl behavior
  - Uses Mi for values under 10Gi, Gi for larger values to prevent precision loss
  - Changed from decimal Giga (10^9) to binary GiB (2^30) calculations
  - Fixed nodes panel using stale cached API checks instead of actual data

Fixes #70 