### PR TITLE
issue-74 - fix: UI performance and scaling issues

### DIFF
--- a/hack/kwok/setup-cluster.sh
+++ b/hack/kwok/setup-cluster.sh
@@ -142,7 +142,7 @@ spec:
   path: /metrics/nodes/{nodeName}/metrics/resource
 EOF
 
-    METRICS_CONFIG="--enable-metrics-server -c $METRICS_FILE"
+    METRICS_CONFIG="--enable=metrics-server --enable-crds=Metric --enable-crds=ClusterResourceUsage -c $METRICS_FILE"
 fi
 
 # 2. Create kwokctl cluster
@@ -154,6 +154,12 @@ fi
 kwokctl create cluster --name "$CLUSTER_NAME" $METRICS_CONFIG --wait 60s
 kubectl config use-context "kwok-$CLUSTER_NAME"
 sleep 5
+
+# Apply metrics configuration to the cluster if enabled
+if [ "$ENABLE_METRICS" = "true" ]; then
+    echo "2a. Applying metrics configuration to cluster..."
+    kubectl apply -f "$METRICS_FILE"
+fi
 
 # 3. Generate nodes manifest
 echo "3. Generating nodes manifest..."


### PR DESCRIPTION
Performance Optimization: Batch Metrics Fetching for Large Clusters

  Pod Controller (k8s/pods_controller.go)
  - Removed individual pod metrics fetching
  - Removed node metrics fetching that caused timeout delays

  View Layer (views/overview/main_panel.go)
  - Replaced N individual GetPodMetrics() calls with single batch GetAllPodMetrics() API call
  - Built metrics map for quick lookup instead of repeated API calls
  - Added graceful fallback when batch metrics fetch fails
  
KWOK Testing Infrastructure changes (hack/kwok/setup-cluster.sh)
  - Fixed deprecated --enable-metrics-server flag syntax to --enable=metrics-server
  - Added --enable-crds=Metric,ClusterResourceUsage for metrics simulation support
  - Embedded metrics-usage.yaml configuration inline
  - Added KWOK_ENABLE_METRICS environment variable for optional metrics-server testing