### PR TITLE
issue-87 - feature: Content filtering

### DIFF
--- a/ui/filter.go
+++ b/ui/filter.go
@@ -1,0 +1,132 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FilterState manages text filtering for a panel
+type FilterState struct {
+	Active    bool   // Filter is confirmed and active
+	Editing   bool   // Currently typing in filter
+	Text      string // Current filter text
+	TotalRows int    // Total rows before filtering
+	MatchRows int    // Rows matching filter
+}
+
+// IsFiltering returns true if filter is active or being edited
+func (f *FilterState) IsFiltering() bool {
+	return f.Active || f.Editing
+}
+
+// Clear resets the filter state completely
+func (f *FilterState) Clear() {
+	f.Active = false
+	f.Editing = false
+	f.Text = ""
+	// MatchRows will be reset on next draw when all rows match
+}
+
+// StartEditing begins filter input mode
+func (f *FilterState) StartEditing() {
+	f.Editing = true
+}
+
+// Confirm finalizes the filter
+func (f *FilterState) Confirm() {
+	if f.Text != "" {
+		f.Active = true
+	}
+	f.Editing = false
+}
+
+// Cancel exits editing mode
+func (f *FilterState) Cancel() {
+	if f.Active {
+		// Keep existing filter
+		f.Editing = false
+	} else {
+		// Clear everything
+		f.Clear()
+	}
+}
+
+// FormatTitle formats a panel title with filter state indicator
+// baseTitle: the panel name (e.g., "Nodes", "Pods")
+// icon: the panel icon
+// Returns formatted title string
+func (f *FilterState) FormatTitle(baseTitle, icon string) string {
+	if f.Editing {
+		if f.Text == "" {
+			return fmt.Sprintf(" %s %s [yellow][Filter: ▌][-] (%d/%d) ",
+				icon, baseTitle, f.MatchRows, f.TotalRows)
+		}
+		return fmt.Sprintf(" %s %s [yellow][Filter: %s▌][-] (%d/%d) ",
+			icon, baseTitle, f.Text, f.MatchRows, f.TotalRows)
+	}
+	if f.Active {
+		return fmt.Sprintf(" %s %s [green][/%s][-] (%d/%d) ",
+			icon, baseTitle, f.Text, f.MatchRows, f.TotalRows)
+	}
+	return fmt.Sprintf(" %s %s (%d) ", icon, baseTitle, f.TotalRows)
+}
+
+// FormatTitleWithScroll formats a panel title with filter state and scroll indicators
+func (f *FilterState) FormatTitleWithScroll(baseTitle, icon string, firstVisible, lastVisible, totalRows int, scrollIndicator, disconnectedSuffix string) string {
+	if f.Editing {
+		if f.Text == "" {
+			return fmt.Sprintf(" %s %s [yellow][Filter: ▌][-] (%d/%d)%s%s ",
+				icon, baseTitle, f.MatchRows, f.TotalRows, scrollIndicator, disconnectedSuffix)
+		}
+		return fmt.Sprintf(" %s %s [yellow][Filter: %s▌][-] (%d/%d)%s%s ",
+			icon, baseTitle, f.Text, f.MatchRows, f.TotalRows, scrollIndicator, disconnectedSuffix)
+	}
+	if f.Active && f.Text != "" {
+		return fmt.Sprintf(" %s %s [green][/%s][-] (%d/%d)%s%s ",
+			icon, baseTitle, f.Text, f.MatchRows, f.TotalRows, scrollIndicator, disconnectedSuffix)
+	}
+
+	// No filter - use standard format (original title)
+	if totalRows == 0 || scrollIndicator == "" {
+		// All content visible or no content - simple count
+		return fmt.Sprintf(" %s %s (%d)%s ", icon, baseTitle, totalRows, disconnectedSuffix)
+	}
+
+	// Show scroll position
+	return fmt.Sprintf(" %s %s (%d-%d/%d)%s%s ",
+		icon, baseTitle, firstVisible, lastVisible, totalRows, scrollIndicator, disconnectedSuffix)
+}
+
+// MatchesRow checks if any cell in the row contains the filter text (case-insensitive)
+func (f *FilterState) MatchesRow(cells []string) bool {
+	if f.Text == "" {
+		return true
+	}
+	filterLower := strings.ToLower(f.Text)
+	for _, cell := range cells {
+		if strings.Contains(strings.ToLower(cell), filterLower) {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleBackspace removes the last character from the filter text
+func (f *FilterState) HandleBackspace() bool {
+	if len(f.Text) > 0 {
+		f.Text = f.Text[:len(f.Text)-1]
+		return true
+	}
+	return false
+}
+
+// AppendChar adds a character to the filter text
+func (f *FilterState) AppendChar(ch rune) {
+	f.Text += string(ch)
+}
+
+// HasEscapableState returns true if there's state that ESC should clear
+// (either editing mode or active filter)
+func (f *FilterState) HasEscapableState() bool {
+	return f.Editing || f.Active
+}

--- a/ui/filter_test.go
+++ b/ui/filter_test.go
@@ -1,0 +1,210 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestFilterState_MatchesRow(t *testing.T) {
+	tests := []struct {
+		name     string
+		filter   string
+		cells    []string
+		expected bool
+	}{
+		{
+			name:     "empty filter matches all",
+			filter:   "",
+			cells:    []string{"nginx", "Running", "10.0.0.1"},
+			expected: true,
+		},
+		{
+			name:     "exact match",
+			filter:   "nginx",
+			cells:    []string{"nginx-deployment-abc123", "Running", "10.0.0.1"},
+			expected: true,
+		},
+		{
+			name:     "case insensitive match",
+			filter:   "NGINX",
+			cells:    []string{"nginx-deployment-abc123", "Running", "10.0.0.1"},
+			expected: true,
+		},
+		{
+			name:     "partial match",
+			filter:   "dep",
+			cells:    []string{"nginx-deployment-abc123", "Running", "10.0.0.1"},
+			expected: true,
+		},
+		{
+			name:     "no match",
+			filter:   "redis",
+			cells:    []string{"nginx-deployment-abc123", "Running", "10.0.0.1"},
+			expected: false,
+		},
+		{
+			name:     "match in status column",
+			filter:   "run",
+			cells:    []string{"nginx", "Running", "10.0.0.1"},
+			expected: true,
+		},
+		{
+			name:     "match IP address",
+			filter:   "10.0",
+			cells:    []string{"nginx", "Running", "10.0.0.1"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FilterState{Text: tt.filter}
+			result := f.MatchesRow(tt.cells)
+			if result != tt.expected {
+				t.Errorf("MatchesRow() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterState_StateTransitions(t *testing.T) {
+	f := &FilterState{}
+
+	// Initial state
+	if f.Active || f.Editing || f.Text != "" {
+		t.Error("Initial state should be inactive")
+	}
+
+	// Start editing
+	f.StartEditing()
+	if !f.Editing || f.Active {
+		t.Error("After StartEditing, should be editing but not active")
+	}
+
+	// Add text
+	f.AppendChar('n')
+	f.AppendChar('g')
+	f.AppendChar('i')
+	f.AppendChar('n')
+	f.AppendChar('x')
+	if f.Text != "nginx" {
+		t.Errorf("Text = %q, want 'nginx'", f.Text)
+	}
+
+	// Backspace
+	f.HandleBackspace()
+	if f.Text != "ngin" {
+		t.Errorf("After backspace, Text = %q, want 'ngin'", f.Text)
+	}
+
+	// Confirm
+	f.AppendChar('x')
+	f.Confirm()
+	if !f.Active || f.Editing {
+		t.Error("After Confirm, should be active but not editing")
+	}
+
+	// Clear
+	f.Clear()
+	if f.Active || f.Editing || f.Text != "" {
+		t.Error("After Clear, should be fully reset")
+	}
+}
+
+func TestFilterState_CancelBehavior(t *testing.T) {
+	t.Run("cancel without active filter clears", func(t *testing.T) {
+		f := &FilterState{}
+		f.StartEditing()
+		f.AppendChar('t')
+		f.AppendChar('e')
+		f.AppendChar('s')
+		f.AppendChar('t')
+		f.Cancel()
+
+		if f.Active || f.Editing || f.Text != "" {
+			t.Error("Cancel without active filter should clear everything")
+		}
+	})
+
+	t.Run("cancel with active filter keeps it", func(t *testing.T) {
+		f := &FilterState{}
+		f.StartEditing()
+		f.AppendChar('t')
+		f.AppendChar('e')
+		f.AppendChar('s')
+		f.AppendChar('t')
+		f.Confirm()
+
+		// Now edit again and cancel
+		f.StartEditing()
+		f.AppendChar('2')
+		f.Cancel()
+
+		// Should keep the confirmed filter
+		if !f.Active || f.Editing {
+			t.Error("After Cancel with active filter, should still be active")
+		}
+	})
+}
+
+func TestFilterState_FormatTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    FilterState
+		base     string
+		icon     string
+		contains []string
+	}{
+		{
+			name:     "no filter",
+			state:    FilterState{TotalRows: 10, MatchRows: 10},
+			base:     "Pods",
+			icon:     "📦",
+			contains: []string{"Pods", "(10)"},
+		},
+		{
+			name:     "editing empty",
+			state:    FilterState{Editing: true, TotalRows: 10, MatchRows: 10},
+			base:     "Pods",
+			icon:     "📦",
+			contains: []string{"Filter:", "▌"},
+		},
+		{
+			name:     "editing with text",
+			state:    FilterState{Editing: true, Text: "nginx", TotalRows: 10, MatchRows: 3},
+			base:     "Pods",
+			icon:     "📦",
+			contains: []string{"Filter:", "nginx", "3/10"},
+		},
+		{
+			name:     "active filter",
+			state:    FilterState{Active: true, Text: "nginx", TotalRows: 10, MatchRows: 3},
+			base:     "Pods",
+			icon:     "📦",
+			contains: []string{"/nginx", "3/10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.state.FormatTitle(tt.base, tt.icon)
+			for _, s := range tt.contains {
+				if !containsString(result, s) {
+					t.Errorf("FormatTitle() = %q, should contain %q", result, s)
+				}
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/ui/panel.go
+++ b/ui/panel.go
@@ -22,3 +22,13 @@ type PanelController interface {
 	Panel
 	Run(context.Context) error
 }
+
+// EscapablePanel is an optional interface that panels can implement
+// to indicate they have state that ESC should clear before quitting the app
+type EscapablePanel interface {
+	// HasEscapableState returns true if the panel has state that ESC should clear
+	// (e.g., active filter, edit mode, selection)
+	HasEscapableState() bool
+	// HandleEscape handles ESC key press - clears state and returns true if handled
+	HandleEscape() bool
+}

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -112,6 +112,40 @@ func (p *MainPanel) GetChildrenViews() []tview.Primitive {
 	return p.children
 }
 
+// HasEscapableState implements ui.EscapablePanel by checking child panels
+func (p *MainPanel) HasEscapableState() bool {
+	// Check node panel
+	if escapable, ok := p.nodePanel.(ui.EscapablePanel); ok {
+		if escapable.HasEscapableState() {
+			return true
+		}
+	}
+	// Check pod panel
+	if escapable, ok := p.podPanel.(ui.EscapablePanel); ok {
+		if escapable.HasEscapableState() {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleEscape implements ui.EscapablePanel by delegating to child panels
+func (p *MainPanel) HandleEscape() bool {
+	// Try node panel first
+	if escapable, ok := p.nodePanel.(ui.EscapablePanel); ok {
+		if escapable.HandleEscape() {
+			return true
+		}
+	}
+	// Try pod panel
+	if escapable, ok := p.podPanel.(ui.EscapablePanel); ok {
+		if escapable.HandleEscape() {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *MainPanel) Run(ctx context.Context) error {
 	p.Layout(nil)
 	ctrl := p.app.GetK8sClient().Controller()


### PR DESCRIPTION
Support for content filtering
  - Add table row filtering with `/` key trigger for both Node and Pod panels
  - Implement proper ESC key handling that clears filters before quitting the app

Fixes #87 