### PR TITLE
issue-91 - chore: Unified storage backend

### DIFF
--- a/cmd/ktop.go
+++ b/cmd/ktop.go
@@ -82,7 +82,7 @@ func NewKtopCmd() *cobra.Command {
 	// Metrics source flags
 	cmd.Flags().StringVar(&o.metricsSource, "metrics-source", "metrics-server",
 		"Metrics source: 'metrics-server' (default) or 'prometheus'")
-	cmd.Flags().StringVar(&o.prometheusScrapeInterval, "prometheus-scrape-interval", "15s",
+	cmd.Flags().StringVar(&o.prometheusScrapeInterval, "prometheus-scrape-interval", "5s",
 		"Prometheus scrape interval (e.g., 10s, 30s, 1m)")
 	cmd.Flags().StringVar(&o.prometheusRetention, "prometheus-retention", "1h",
 		"Prometheus metrics retention time (e.g., 30m, 1h, 2h)")

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ func DefaultConfig() *Config {
 			Type: "metrics-server",
 		},
 		Prometheus: PrometheusConfig{
-			ScrapeInterval: 15 * time.Second,
+			ScrapeInterval: 5 * time.Second,
 			RetentionTime:  1 * time.Hour,
 			MaxSamples:     10000,
 			Components: []prom.ComponentType{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,8 +20,8 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	// Verify Prometheus defaults
-	if cfg.Prometheus.ScrapeInterval != 15*time.Second {
-		t.Errorf("Expected default scrape interval 15s, got %v", cfg.Prometheus.ScrapeInterval)
+	if cfg.Prometheus.ScrapeInterval != 5*time.Second {
+		t.Errorf("Expected default scrape interval 5s, got %v", cfg.Prometheus.ScrapeInterval)
 	}
 
 	if cfg.Prometheus.RetentionTime != 1*time.Hour {

--- a/metrics/prom/prom_source_test.go
+++ b/metrics/prom/prom_source_test.go
@@ -204,8 +204,8 @@ func TestNewPromMetricsSource_WithNilConfig(t *testing.T) {
 	}
 
 	// Verify default config values
-	if source.config.ScrapeInterval != 15*time.Second {
-		t.Errorf("Expected default scrape interval 15s, got %v", source.config.ScrapeInterval)
+	if source.config.ScrapeInterval != 5*time.Second {
+		t.Errorf("Expected default scrape interval 5s, got %v", source.config.ScrapeInterval)
 	}
 
 	if source.config.RetentionTime != 1*time.Hour {
@@ -224,8 +224,8 @@ func TestDefaultPromConfig(t *testing.T) {
 		t.Error("Expected Enabled to be true")
 	}
 
-	if config.ScrapeInterval != 15*time.Second {
-		t.Errorf("Expected ScrapeInterval 15s, got %v", config.ScrapeInterval)
+	if config.ScrapeInterval != 5*time.Second {
+		t.Errorf("Expected ScrapeInterval 5s, got %v", config.ScrapeInterval)
 	}
 
 	if config.RetentionTime != 1*time.Hour {

--- a/prom/controller_test.go
+++ b/prom/controller_test.go
@@ -435,9 +435,12 @@ func TestControllerErrorHandling(t *testing.T) {
 	kubeConfig := &rest.Config{Host: "https://invalid-cluster"}
 	controller := NewCollectorController(kubeConfig, DefaultScrapeConfig())
 
+	var mu sync.Mutex
 	errorCount := 0
 	controller.SetErrorCallback(func(ComponentType, error) {
+		mu.Lock()
 		errorCount++
+		mu.Unlock()
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -453,6 +456,8 @@ func TestControllerErrorHandling(t *testing.T) {
 	// The controller should handle errors gracefully
 	// We can check that error callbacks were called if errors occurred
 	// But we don't require errors for the test to pass
-	_ = err        // Use the variable
+	mu.Lock()
 	_ = errorCount // Use the variable
+	mu.Unlock()
+	_ = err // Use the variable
 }

--- a/prom/ring_buffer.go
+++ b/prom/ring_buffer.go
@@ -1,0 +1,158 @@
+package prom
+
+// RingBuffer provides a fixed-size, allocation-free circular buffer for storing samples.
+// Once full, new additions overwrite the oldest entries automatically.
+// This is more memory-efficient than bounded slices as it avoids reallocations
+// and GC pressure from slice trimming operations.
+type RingBuffer[T any] struct {
+	data  []T
+	size  int
+	head  int // Next write position
+	count int // Current number of elements (0 to size)
+}
+
+// NewRingBuffer creates a new ring buffer with the specified capacity.
+// The buffer is pre-allocated to avoid allocations during normal operation.
+func NewRingBuffer[T any](size int) *RingBuffer[T] {
+	if size <= 0 {
+		size = 1
+	}
+	return &RingBuffer[T]{
+		data: make([]T, size),
+		size: size,
+	}
+}
+
+// Add appends a value to the buffer.
+// If the buffer is full, the oldest value is overwritten.
+// This operation is O(1) and does not allocate.
+func (rb *RingBuffer[T]) Add(value T) {
+	rb.data[rb.head] = value
+	rb.head = (rb.head + 1) % rb.size
+	if rb.count < rb.size {
+		rb.count++
+	}
+}
+
+// Len returns the current number of elements in the buffer.
+func (rb *RingBuffer[T]) Len() int {
+	return rb.count
+}
+
+// Cap returns the maximum capacity of the buffer.
+func (rb *RingBuffer[T]) Cap() int {
+	return rb.size
+}
+
+// IsEmpty returns true if the buffer contains no elements.
+func (rb *RingBuffer[T]) IsEmpty() bool {
+	return rb.count == 0
+}
+
+// IsFull returns true if the buffer is at capacity.
+func (rb *RingBuffer[T]) IsFull() bool {
+	return rb.count == rb.size
+}
+
+// Last returns the most recently added value.
+// Returns the zero value and false if the buffer is empty.
+func (rb *RingBuffer[T]) Last() (T, bool) {
+	if rb.count == 0 {
+		var zero T
+		return zero, false
+	}
+	// head points to next write position, so last written is head-1
+	idx := (rb.head - 1 + rb.size) % rb.size
+	return rb.data[idx], true
+}
+
+// First returns the oldest value in the buffer.
+// Returns the zero value and false if the buffer is empty.
+func (rb *RingBuffer[T]) First() (T, bool) {
+	if rb.count == 0 {
+		var zero T
+		return zero, false
+	}
+	if rb.count < rb.size {
+		// Not full yet - oldest is at index 0
+		return rb.data[0], true
+	}
+	// Full - oldest is at head (next to be overwritten)
+	return rb.data[rb.head], true
+}
+
+// Get returns the element at the given index (0 = oldest, Len()-1 = newest).
+// Returns the zero value and false if index is out of bounds.
+func (rb *RingBuffer[T]) Get(index int) (T, bool) {
+	if index < 0 || index >= rb.count {
+		var zero T
+		return zero, false
+	}
+
+	var actualIdx int
+	if rb.count < rb.size {
+		// Not full - data starts at 0
+		actualIdx = index
+	} else {
+		// Full - oldest is at head
+		actualIdx = (rb.head + index) % rb.size
+	}
+	return rb.data[actualIdx], true
+}
+
+// Slice returns all values in chronological order (oldest first).
+// This allocates a new slice - use iterator methods for zero-allocation access.
+func (rb *RingBuffer[T]) Slice() []T {
+	if rb.count == 0 {
+		return nil
+	}
+
+	result := make([]T, rb.count)
+	if rb.count < rb.size {
+		// Not full yet - data is contiguous from 0
+		copy(result, rb.data[:rb.count])
+	} else {
+		// Full - data wraps around
+		// Oldest is at head, newest is at head-1
+		tail := rb.size - rb.head
+		copy(result, rb.data[rb.head:])        // [head, size) -> oldest portion
+		copy(result[tail:], rb.data[:rb.head]) // [0, head) -> newest portion
+	}
+	return result
+}
+
+// SliceFrom returns values from the given index to the end (newest).
+// Index 0 = oldest. This allocates a new slice.
+func (rb *RingBuffer[T]) SliceFrom(startIndex int) []T {
+	if startIndex < 0 || startIndex >= rb.count {
+		return nil
+	}
+
+	length := rb.count - startIndex
+	result := make([]T, length)
+
+	for i := 0; i < length; i++ {
+		val, _ := rb.Get(startIndex + i)
+		result[i] = val
+	}
+	return result
+}
+
+// Range iterates over all elements in chronological order.
+// The callback receives the index (0 = oldest) and value.
+// Return false from the callback to stop iteration early.
+func (rb *RingBuffer[T]) Range(fn func(index int, value T) bool) {
+	for i := 0; i < rb.count; i++ {
+		val, _ := rb.Get(i)
+		if !fn(i, val) {
+			return
+		}
+	}
+}
+
+// Clear removes all elements from the buffer.
+// The underlying storage is retained for reuse.
+func (rb *RingBuffer[T]) Clear() {
+	rb.head = 0
+	rb.count = 0
+}

--- a/prom/ring_buffer_test.go
+++ b/prom/ring_buffer_test.go
@@ -1,0 +1,354 @@
+package prom
+
+import (
+	"testing"
+)
+
+func TestNewRingBuffer(t *testing.T) {
+	rb := NewRingBuffer[int](5)
+	if rb.Len() != 0 {
+		t.Errorf("expected Len() = 0, got %d", rb.Len())
+	}
+	if rb.Cap() != 5 {
+		t.Errorf("expected Cap() = 5, got %d", rb.Cap())
+	}
+	if !rb.IsEmpty() {
+		t.Error("expected IsEmpty() = true")
+	}
+	if rb.IsFull() {
+		t.Error("expected IsFull() = false")
+	}
+}
+
+func TestNewRingBufferZeroSize(t *testing.T) {
+	rb := NewRingBuffer[int](0)
+	if rb.Cap() != 1 {
+		t.Errorf("expected Cap() = 1 for zero size, got %d", rb.Cap())
+	}
+}
+
+func TestRingBufferAdd(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	rb.Add(1)
+	if rb.Len() != 1 {
+		t.Errorf("expected Len() = 1, got %d", rb.Len())
+	}
+
+	rb.Add(2)
+	rb.Add(3)
+	if rb.Len() != 3 {
+		t.Errorf("expected Len() = 3, got %d", rb.Len())
+	}
+	if !rb.IsFull() {
+		t.Error("expected IsFull() = true")
+	}
+
+	// Add one more - should overwrite oldest
+	rb.Add(4)
+	if rb.Len() != 3 {
+		t.Errorf("expected Len() = 3 after overflow, got %d", rb.Len())
+	}
+}
+
+func TestRingBufferFirstLast(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Empty buffer
+	_, ok := rb.First()
+	if ok {
+		t.Error("expected First() to return false for empty buffer")
+	}
+	_, ok = rb.Last()
+	if ok {
+		t.Error("expected Last() to return false for empty buffer")
+	}
+
+	// Add some values
+	rb.Add(1)
+	rb.Add(2)
+	rb.Add(3)
+
+	first, ok := rb.First()
+	if !ok || first != 1 {
+		t.Errorf("expected First() = 1, got %d", first)
+	}
+
+	last, ok := rb.Last()
+	if !ok || last != 3 {
+		t.Errorf("expected Last() = 3, got %d", last)
+	}
+
+	// Overflow - oldest should now be 2
+	rb.Add(4)
+
+	first, ok = rb.First()
+	if !ok || first != 2 {
+		t.Errorf("expected First() = 2 after overflow, got %d", first)
+	}
+
+	last, ok = rb.Last()
+	if !ok || last != 4 {
+		t.Errorf("expected Last() = 4 after overflow, got %d", last)
+	}
+}
+
+func TestRingBufferGet(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Empty buffer
+	_, ok := rb.Get(0)
+	if ok {
+		t.Error("expected Get(0) to return false for empty buffer")
+	}
+
+	rb.Add(1)
+	rb.Add(2)
+	rb.Add(3)
+
+	// Valid indices
+	for i, expected := range []int{1, 2, 3} {
+		val, ok := rb.Get(i)
+		if !ok {
+			t.Errorf("expected Get(%d) to return true", i)
+		}
+		if val != expected {
+			t.Errorf("expected Get(%d) = %d, got %d", i, expected, val)
+		}
+	}
+
+	// Out of bounds
+	_, ok = rb.Get(-1)
+	if ok {
+		t.Error("expected Get(-1) to return false")
+	}
+	_, ok = rb.Get(3)
+	if ok {
+		t.Error("expected Get(3) to return false")
+	}
+
+	// After overflow
+	rb.Add(4)
+	rb.Add(5)
+
+	expected := []int{3, 4, 5}
+	for i, exp := range expected {
+		val, ok := rb.Get(i)
+		if !ok || val != exp {
+			t.Errorf("after overflow: expected Get(%d) = %d, got %d", i, exp, val)
+		}
+	}
+}
+
+func TestRingBufferSlice(t *testing.T) {
+	rb := NewRingBuffer[int](5)
+
+	// Empty buffer
+	slice := rb.Slice()
+	if slice != nil {
+		t.Errorf("expected nil slice for empty buffer, got %v", slice)
+	}
+
+	// Partially filled
+	rb.Add(1)
+	rb.Add(2)
+	rb.Add(3)
+
+	slice = rb.Slice()
+	expected := []int{1, 2, 3}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+
+	// Full buffer
+	rb.Add(4)
+	rb.Add(5)
+
+	slice = rb.Slice()
+	expected = []int{1, 2, 3, 4, 5}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+
+	// After overflow
+	rb.Add(6)
+	rb.Add(7)
+
+	slice = rb.Slice()
+	expected = []int{3, 4, 5, 6, 7}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("after overflow: expected %v, got %v", expected, slice)
+	}
+}
+
+func TestRingBufferSliceFrom(t *testing.T) {
+	rb := NewRingBuffer[int](5)
+	rb.Add(1)
+	rb.Add(2)
+	rb.Add(3)
+	rb.Add(4)
+	rb.Add(5)
+
+	// From middle
+	slice := rb.SliceFrom(2)
+	expected := []int{3, 4, 5}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+
+	// From start
+	slice = rb.SliceFrom(0)
+	expected = []int{1, 2, 3, 4, 5}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+
+	// From last
+	slice = rb.SliceFrom(4)
+	expected = []int{5}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+
+	// Out of bounds
+	slice = rb.SliceFrom(5)
+	if slice != nil {
+		t.Errorf("expected nil for out of bounds, got %v", slice)
+	}
+
+	slice = rb.SliceFrom(-1)
+	if slice != nil {
+		t.Errorf("expected nil for negative index, got %v", slice)
+	}
+}
+
+func TestRingBufferRange(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+	rb.Add(10)
+	rb.Add(20)
+	rb.Add(30)
+
+	var collected []int
+	rb.Range(func(index int, value int) bool {
+		collected = append(collected, value)
+		return true
+	})
+
+	expected := []int{10, 20, 30}
+	if !sliceEqual(collected, expected) {
+		t.Errorf("expected %v, got %v", expected, collected)
+	}
+
+	// Test early termination
+	collected = nil
+	rb.Range(func(index int, value int) bool {
+		collected = append(collected, value)
+		return index < 1 // Stop after index 1
+	})
+
+	expected = []int{10, 20}
+	if !sliceEqual(collected, expected) {
+		t.Errorf("expected early termination at %v, got %v", expected, collected)
+	}
+}
+
+func TestRingBufferClear(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+	rb.Add(1)
+	rb.Add(2)
+	rb.Add(3)
+
+	rb.Clear()
+
+	if rb.Len() != 0 {
+		t.Errorf("expected Len() = 0 after Clear(), got %d", rb.Len())
+	}
+	if !rb.IsEmpty() {
+		t.Error("expected IsEmpty() = true after Clear()")
+	}
+
+	// Should be able to add again
+	rb.Add(100)
+	val, ok := rb.Last()
+	if !ok || val != 100 {
+		t.Errorf("expected Last() = 100 after re-add, got %d", val)
+	}
+}
+
+func TestRingBufferWithMetricSample(t *testing.T) {
+	rb := NewRingBuffer[MetricSample](3)
+
+	rb.Add(MetricSample{Timestamp: 1000, Value: 1.0})
+	rb.Add(MetricSample{Timestamp: 2000, Value: 2.0})
+	rb.Add(MetricSample{Timestamp: 3000, Value: 3.0})
+
+	last, ok := rb.Last()
+	if !ok {
+		t.Fatal("expected Last() to return true")
+	}
+	if last.Timestamp != 3000 || last.Value != 3.0 {
+		t.Errorf("expected {3000, 3.0}, got {%d, %f}", last.Timestamp, last.Value)
+	}
+
+	// Overflow
+	rb.Add(MetricSample{Timestamp: 4000, Value: 4.0})
+
+	first, ok := rb.First()
+	if !ok {
+		t.Fatal("expected First() to return true")
+	}
+	if first.Timestamp != 2000 || first.Value != 2.0 {
+		t.Errorf("expected {2000, 2.0}, got {%d, %f}", first.Timestamp, first.Value)
+	}
+
+	slice := rb.Slice()
+	if len(slice) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(slice))
+	}
+	expectedTimestamps := []int64{2000, 3000, 4000}
+	for i, s := range slice {
+		if s.Timestamp != expectedTimestamps[i] {
+			t.Errorf("slice[%d].Timestamp = %d, expected %d", i, s.Timestamp, expectedTimestamps[i])
+		}
+	}
+}
+
+func TestRingBufferWrapAround(t *testing.T) {
+	// Test multiple wrap-arounds to ensure consistency
+	rb := NewRingBuffer[int](3)
+
+	// Fill and overflow multiple times
+	for i := 1; i <= 10; i++ {
+		rb.Add(i)
+	}
+
+	// Should have last 3 values: 8, 9, 10
+	slice := rb.Slice()
+	expected := []int{8, 9, 10}
+	if !sliceEqual(slice, expected) {
+		t.Errorf("after 10 adds to size-3 buffer: expected %v, got %v", expected, slice)
+	}
+
+	first, _ := rb.First()
+	if first != 8 {
+		t.Errorf("expected First() = 8, got %d", first)
+	}
+
+	last, _ := rb.Last()
+	if last != 10 {
+		t.Errorf("expected Last() = 10, got %d", last)
+	}
+}
+
+// Helper function to compare slices
+func sliceEqual[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/prom/scraper.go
+++ b/prom/scraper.go
@@ -486,15 +486,15 @@ func (ks *KubernetesScraper) convertMetricFamily(name string, family *dto.Metric
 			}
 		}
 
-		// Create time series
+		// Create time series with ring buffer
+		samples := NewRingBuffer[MetricSample](1) // Initial capacity of 1
+		samples.Add(MetricSample{
+			Timestamp: timestamp,
+			Value:     value,
+		})
 		timeSeries := &TimeSeries{
-			Labels: lbls,
-			Samples: []MetricSample{
-				{
-					Timestamp: timestamp,
-					Value:     value,
-				},
-			},
+			Labels:  lbls,
+			Samples: samples,
 		}
 
 		metricFamily.TimeSeries = append(metricFamily.TimeSeries, timeSeries)

--- a/prom/scraper_test.go
+++ b/prom/scraper_test.go
@@ -340,11 +340,14 @@ func TestConvertMetricFamily(t *testing.T) {
 	}
 
 	// Check samples
-	if len(timeSeries.Samples) != 1 {
-		t.Fatalf("Expected 1 sample, got %d", len(timeSeries.Samples))
+	if timeSeries.Samples.Len() != 1 {
+		t.Fatalf("Expected 1 sample, got %d", timeSeries.Samples.Len())
 	}
 
-	sample := timeSeries.Samples[0]
+	sample, ok := timeSeries.Samples.Last()
+	if !ok {
+		t.Fatal("Expected sample to be present")
+	}
 	if sample.Value != 123.45 {
 		t.Errorf("Expected value 123.45, got %f", sample.Value)
 	}

--- a/prom/types.go
+++ b/prom/types.go
@@ -29,10 +29,11 @@ type MetricSample struct {
 	Value     float64
 }
 
-// TimeSeries represents a time series with labels and samples
+// TimeSeries represents a time series with labels and samples.
+// Uses a ring buffer for memory-efficient, fixed-size sample storage.
 type TimeSeries struct {
 	Labels  labels.Labels
-	Samples []MetricSample
+	Samples *RingBuffer[MetricSample]
 }
 
 // MetricFamily represents a group of related metrics


### PR DESCRIPTION
   This PR introduces a unified storage mechanism for both Prometheus and Metrics Server sources.

   - New `RingBuffer[T]` Generic Data Structure
   - Memory-efficient circular buffer for time-series data
   - Configurable capacity with automatic eviction
   - `MetricsSource` Interface Extensions to support new storage backend
   - Prometheus Source Improvements
   - Reduced default scrape interval from 15s to 5s for faster startup
   - Stores Metrics Server data in ring buffer for trends

Fixes #91 