### PR TITLE
issue-97 - feat: Support for runtime namespace filtering

### DIFF
--- a/cmd/ktop.go
+++ b/cmd/ktop.go
@@ -186,9 +186,6 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 
 		metricsSource = promSource
 
-		fmt.Println("Warning: Prometheus metrics source is not yet fully integrated with the UI")
-		fmt.Println("         Currently using metrics-server fallback for display")
-
 	case "none":
 		fmt.Println("Using metrics source: None (fallback mode)")
 		fmt.Println("Displaying resource requests/limits only")

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -133,6 +133,14 @@ func (k8s *Client) ClusterContext() string {
 	return k8s.clusterContext
 }
 
+// ClusterName returns the cluster name from kubeconfig (may differ from context name)
+func (k8s *Client) ClusterName() string {
+	if ctx, ok := k8s.apiConfig.Contexts[k8s.clusterContext]; ok {
+		return ctx.Cluster
+	}
+	return k8s.clusterContext // fallback to context name
+}
+
 func (k8s *Client) Username() string {
 	return k8s.username
 }

--- a/ui/panel.go
+++ b/ui/panel.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -31,4 +32,94 @@ type EscapablePanel interface {
 	HasEscapableState() bool
 	// HandleEscape handles ESC key press - clears state and returns true if handled
 	HandleEscape() bool
+}
+
+// FocusablePanel is an optional interface that panels can implement
+// to support visual focus indication with double-border and color change
+type FocusablePanel interface {
+	// SetFocused updates the panel's visual state for focus
+	SetFocused(focused bool)
+}
+
+// SetBoxFocused applies focus styling to a tview.Box (or any type that embeds it)
+// Focused: yellow border color (double-border effect via styling)
+// Unfocused: white border color
+func SetBoxFocused(box *tview.Box, focused bool) {
+	if box == nil {
+		return
+	}
+	if focused {
+		box.SetBorderColor(GetTcellColor(Theme.FocusBorderColor))
+	} else {
+		box.SetBorderColor(GetTcellColor(Theme.UnfocusBorderColor))
+	}
+}
+
+// SetFlexFocused applies focus styling to a tview.Flex container
+// Uses border color change for focus indication
+// Note: Double-border via SetDrawFunc was removed as it overwrites the panel title
+func SetFlexFocused(flex *tview.Flex, focused bool) {
+	if flex == nil {
+		return
+	}
+	if focused {
+		flex.SetBorderColor(GetTcellColor(Theme.FocusBorderColor))
+	} else {
+		flex.SetBorderColor(GetTcellColor(Theme.UnfocusBorderColor))
+	}
+}
+
+// SetTableFocused applies focus styling to a tview.Table
+func SetTableFocused(table *tview.Table, focused bool) {
+	if table == nil {
+		return
+	}
+	if focused {
+		table.SetBorderColor(GetTcellColor(Theme.FocusBorderColor))
+	} else {
+		table.SetBorderColor(GetTcellColor(Theme.UnfocusBorderColor))
+	}
+}
+
+// FocusBorderColor returns the tcell color for focused panels
+func FocusBorderColor() tcell.Color {
+	return GetTcellColor(Theme.FocusBorderColor)
+}
+
+// UnfocusBorderColor returns the tcell color for unfocused panels
+func UnfocusBorderColor() tcell.Color {
+	return GetTcellColor(Theme.UnfocusBorderColor)
+}
+
+// Double-border Unicode box-drawing characters
+const (
+	DoubleBorderHorizontal  = '═'
+	DoubleBorderVertical    = '║'
+	DoubleBorderTopLeft     = '╔'
+	DoubleBorderTopRight    = '╗'
+	DoubleBorderBottomLeft  = '╚'
+	DoubleBorderBottomRight = '╝'
+)
+
+// DrawDoubleBorder draws a double-line border around the given rectangle
+func DrawDoubleBorder(screen tcell.Screen, x, y, width, height int, color tcell.Color) {
+	style := tcell.StyleDefault.Foreground(color)
+
+	// Draw corners
+	screen.SetContent(x, y, DoubleBorderTopLeft, nil, style)
+	screen.SetContent(x+width-1, y, DoubleBorderTopRight, nil, style)
+	screen.SetContent(x, y+height-1, DoubleBorderBottomLeft, nil, style)
+	screen.SetContent(x+width-1, y+height-1, DoubleBorderBottomRight, nil, style)
+
+	// Draw horizontal lines
+	for i := x + 1; i < x+width-1; i++ {
+		screen.SetContent(i, y, DoubleBorderHorizontal, nil, style)
+		screen.SetContent(i, y+height-1, DoubleBorderHorizontal, nil, style)
+	}
+
+	// Draw vertical lines
+	for i := y + 1; i < y+height-1; i++ {
+		screen.SetContent(x, i, DoubleBorderVertical, nil, style)
+		screen.SetContent(x+width-1, i, DoubleBorderVertical, nil, style)
+	}
 }

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -64,6 +64,10 @@ var Theme = struct {
 	TrendHighColor     string  // Color when percentage >= 80% (red)
 	TrendThreshold     float64 // Percentage change threshold (0.05 = 5%)
 	TrendHighThreshold float64 // Percentage threshold for red arrow (0.80 = 80%)
+
+	// Panel focus colors
+	FocusBorderColor   string // Border color when panel is focused (yellow)
+	UnfocusBorderColor string // Border color when panel is unfocused (white)
 }{
 	// Header colors
 	HeaderBackground:    "darkgreen",
@@ -124,6 +128,10 @@ var Theme = struct {
 	TrendHighColor:     "red",       // Red when percentage >= 80%
 	TrendThreshold:     0.05,        // 5% change triggers arrow
 	TrendHighThreshold: 0.80,        // 80% threshold for red arrow
+
+	// Panel focus colors
+	FocusBorderColor:   "yellow", // Border color when panel is focused
+	UnfocusBorderColor: "white",  // Border color when panel is unfocused
 }
 
 // FormatTag returns a tview color/style tag string

--- a/views/overview/node_panel.go
+++ b/views/overview/node_panel.go
@@ -573,6 +573,11 @@ func (p *nodePanel) GetChildrenViews() []tview.Primitive {
 	return p.children
 }
 
+// SetFocused implements ui.FocusablePanel - updates visual focus state
+func (p *nodePanel) SetFocused(focused bool) {
+	ui.SetFlexFocused(p.root, focused)
+}
+
 // getNodeCells extracts text values from a node model for filter matching
 func (p *nodePanel) getNodeCells(node model.NodeModel) []string {
 	return []string{

--- a/views/overview/pod_panel.go
+++ b/views/overview/pod_panel.go
@@ -587,6 +587,11 @@ func (p *podPanel) GetChildrenViews() []tview.Primitive {
 	return p.children
 }
 
+// SetFocused implements ui.FocusablePanel - updates visual focus state
+func (p *podPanel) SetFocused(focused bool) {
+	ui.SetFlexFocused(p.root, focused)
+}
+
 // getPodCells extracts text values from a pod model for filter matching
 func (p *podPanel) getPodCells(pod model.PodModel) []string {
 	return []string{

--- a/views/overview/summary_panel.go
+++ b/views/overview/summary_panel.go
@@ -226,3 +226,8 @@ func (p *clusterSummaryPanel) GetRootView() tview.Primitive {
 func (p *clusterSummaryPanel) GetChildrenViews() []tview.Primitive {
 	return p.children
 }
+
+// SetFocused implements ui.FocusablePanel - updates visual focus state
+func (p *clusterSummaryPanel) SetFocused(focused bool) {
+	ui.SetFlexFocused(p.root, focused)
+}


### PR DESCRIPTION
  Implements runtime namespace filtering for pods via the header panel.
  - Press `/` when header is focused to filter pods by namespace
  - Live filtering as you type - pods update immediately
  - ESC clears active filter and immediately refreshes pod list
  - Fixed several bugs 
  - Enhanced the header