### PR TITLE
issue-103 - chore: Redesign the Cluster Summary

### DIFF
--- a/metrics/source.go
+++ b/metrics/source.go
@@ -95,6 +95,14 @@ type NodeMetrics struct {
 	// DiskUsage is the current disk usage in bytes
 	DiskUsage *resource.Quantity
 
+	// Network rates (bytes/sec) - calculated from counter deltas
+	NetworkRxRate float64
+	NetworkTxRate float64
+
+	// Disk I/O rates (bytes/sec) - calculated from counter deltas
+	DiskReadRate  float64
+	DiskWriteRate float64
+
 	// LoadAverage1m is the 1-minute load average
 	LoadAverage1m float64
 

--- a/ui/format.go
+++ b/ui/format.go
@@ -32,3 +32,35 @@ func FormatMemory(qty *resource.Quantity) string {
 	// Display in Mi for everything else
 	return fmt.Sprintf("%4dMi", mi) // Fixed width: 4 digits + "Mi"
 }
+
+// FormatBytesRate formats bytes/sec as human-readable (e.g., "1.2M/s")
+// Uses K/M/G suffixes for compact display
+func FormatBytesRate(bytesPerSec float64) string {
+	if bytesPerSec < 0 {
+		bytesPerSec = 0
+	}
+	if bytesPerSec < 1024 {
+		return fmt.Sprintf("%.0fB/s", bytesPerSec)
+	} else if bytesPerSec < 1024*1024 {
+		return fmt.Sprintf("%.1fK/s", bytesPerSec/1024)
+	} else if bytesPerSec < 1024*1024*1024 {
+		return fmt.Sprintf("%.1fM/s", bytesPerSec/(1024*1024))
+	}
+	return fmt.Sprintf("%.1fG/s", bytesPerSec/(1024*1024*1024))
+}
+
+// FormatBytes formats bytes as human-readable (e.g., "1.2G")
+// Uses K/M/G suffixes for compact display
+func FormatBytes(bytes int64) string {
+	if bytes < 0 {
+		bytes = 0
+	}
+	if bytes < 1024 {
+		return fmt.Sprintf("%dB", bytes)
+	} else if bytes < 1024*1024 {
+		return fmt.Sprintf("%.1fK", float64(bytes)/1024)
+	} else if bytes < 1024*1024*1024 {
+		return fmt.Sprintf("%.1fM", float64(bytes)/(1024*1024))
+	}
+	return fmt.Sprintf("%.1fG", float64(bytes)/(1024*1024*1024))
+}

--- a/ui/sparkline_state.go
+++ b/ui/sparkline_state.go
@@ -78,6 +78,11 @@ func (s *SparklineState) SetStyle(style SparklineStyle) {
 	s.style = style
 }
 
+// Height returns the current height of the sparkline
+func (s *SparklineState) Height() int {
+	return s.height
+}
+
 // Push adds a new value (0.0 to 1.0) to the right, shifting all values left.
 // The oldest value (leftmost) is discarded.
 func (s *SparklineState) Push(value float64) {
@@ -104,6 +109,25 @@ func (s *SparklineState) Render() string {
 		return s.renderSingleLine()
 	}
 	return s.renderMultiLine()
+}
+
+// RenderBottomAligned returns the sparkline padded to totalHeight with empty lines at top.
+// This makes the sparkline appear bottom-aligned within a container of totalHeight rows.
+// If totalHeight <= s.height, behaves the same as Render().
+func (s *SparklineState) RenderBottomAligned(totalHeight int) string {
+	content := s.Render()
+	if totalHeight <= s.height {
+		return content
+	}
+
+	// Add empty lines at the top to push content to bottom
+	padding := totalHeight - s.height
+	var result strings.Builder
+	for i := 0; i < padding; i++ {
+		result.WriteString("\n")
+	}
+	result.WriteString(content)
+	return result.String()
 }
 
 // renderSingleLine renders a single-line sparkline with partial block characters

--- a/views/model/summary_model.go
+++ b/views/model/summary_model.go
@@ -35,4 +35,35 @@ type ClusterSummary struct {
 	PVsTotal                *resource.Quantity
 	PVCCount                int
 	PVCsTotal               *resource.Quantity
+
+	// === Prometheus-Enhanced Fields ===
+
+	// Metrics source type for dynamic layout
+	MetricsSourceType string // "prometheus" or "metrics-server"
+
+	// Container stats
+	ContainerCount int // Total running containers
+
+	// Network I/O (aggregated across nodes)
+	NetworkRxBytes *resource.Quantity
+	NetworkTxBytes *resource.Quantity
+	NetworkRxRate  float64 // Bytes/sec received
+	NetworkTxRate  float64 // Bytes/sec transmitted
+
+	// Disk I/O (aggregated across nodes)
+	DiskReadBytes  *resource.Quantity
+	DiskWriteBytes *resource.Quantity
+	DiskReadRate   float64 // Bytes/sec read
+	DiskWriteRate  float64 // Bytes/sec written
+
+	// Health indicators
+	ContainerRestarts1h int     // Container restarts in last hour
+	OOMKillCount        int     // OOM kills in last hour
+	NodePressureCount   int     // Nodes with memory/disk/PID pressure
+	CPUThrottledPercent float64 // Avg CPU throttling across containers
+
+	// Load averages (cluster-wide average)
+	LoadAverage1m  float64
+	LoadAverage5m  float64
+	LoadAverage15m float64
 }

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vladimirvivien/ktop/ui"
 	"github.com/vladimirvivien/ktop/views/model"
 	v1 "k8s.io/api/core/v1"
+	// metrics package imported for SourceTypePrometheus constant
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -99,8 +100,17 @@ func (p *MainPanel) Layout(data interface{}) {
 		p.podPanel,
 	}
 
+	// Determine summary panel height based on metrics source
+	summaryHeight := 12 // Default for Metrics Server
+	if p.metricsSource != nil {
+		info := p.metricsSource.GetSourceInfo()
+		if info.Type == metrics.SourceTypePrometheus {
+			summaryHeight = 14 // Prometheus: stats + 4 sparklines + enhanced stats
+		}
+	}
+
 	view := tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(p.clusterSummaryPanel.GetRootView(), 12, 0, false).
+		AddItem(p.clusterSummaryPanel.GetRootView(), summaryHeight, 0, false).
 		AddItem(p.nodePanel.GetRootView(), 0, 3, true). // 30% of remaining
 		AddItem(p.podPanel.GetRootView(), 0, 7, true)   // 70% of remaining
 

--- a/views/overview/summary_panel.go
+++ b/views/overview/summary_panel.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rivo/tview"
 	"github.com/vladimirvivien/ktop/application"
+	"github.com/vladimirvivien/ktop/metrics"
 	"github.com/vladimirvivien/ktop/ui"
 	"github.com/vladimirvivien/ktop/views/model"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -23,6 +24,18 @@ type clusterSummaryPanel struct {
 	// Stateful sparklines for smooth sliding animation
 	cpuSparkline *ui.SparklineState
 	memSparkline *ui.SparklineState
+
+	// Prometheus-only views (conditionally shown)
+	netView       *tview.TextView // Network I/O sparkline
+	diskView      *tview.TextView // Disk I/O sparkline
+	enhancedStats *tview.TextView // Enhanced stats row
+
+	// Prometheus-only sparklines
+	netSparkline  *ui.SparklineState
+	diskSparkline *ui.SparklineState
+
+	// Layout mode
+	prometheusMode bool
 }
 
 func NewClusterSummaryPanel(app *application.Application, title string) ui.Panel {
@@ -35,38 +48,75 @@ func NewClusterSummaryPanel(app *application.Application, title string) ui.Panel
 func (p *clusterSummaryPanel) GetTitle() string {
 	return p.title
 }
+
+// createSparklineView creates a styled text view for sparklines
+func (p *clusterSummaryPanel) createSparklineView() *tview.TextView {
+	view := tview.NewTextView()
+	view.SetDynamicColors(true)
+	view.SetTextAlign(tview.AlignCenter)
+	view.SetBorder(true)
+	view.SetBorderPadding(0, 0, 0, 0)
+	view.SetTitleAlign(tview.AlignCenter)
+	return view
+}
+
 func (p *clusterSummaryPanel) Layout(data interface{}) {
+	// Detect metrics source type
+	metricsSource := p.app.GetMetricsSource()
+	if metricsSource != nil {
+		info := metricsSource.GetSourceInfo()
+		p.prometheusMode = (info.Type == metrics.SourceTypePrometheus)
+	}
+
 	// Stats view (single line, with border for visual separation)
 	p.statsView = tview.NewTextView()
 	p.statsView.SetDynamicColors(true)
 	p.statsView.SetBorder(true)
 	p.statsView.SetBorderPadding(0, 0, 0, 0)
 
-	// CPU sparkline view
-	p.cpuView = tview.NewTextView()
-	p.cpuView.SetDynamicColors(true)
-	p.cpuView.SetTextAlign(tview.AlignCenter)
-	p.cpuView.SetBorder(true)
-	p.cpuView.SetBorderPadding(0, 0, 0, 0)
-	p.cpuView.SetTitleAlign(tview.AlignCenter)
+	// CPU and MEM sparkline views (always shown)
+	p.cpuView = p.createSparklineView()
+	p.memView = p.createSparklineView()
 
-	// MEM sparkline view
-	p.memView = tview.NewTextView()
-	p.memView.SetDynamicColors(true)
-	p.memView.SetTextAlign(tview.AlignCenter)
-	p.memView.SetBorder(true)
-	p.memView.SetBorderPadding(0, 0, 0, 0)
-	p.memView.SetTitleAlign(tview.AlignCenter)
+	if p.prometheusMode {
+		// === PROMETHEUS LAYOUT: 4 sparklines on one row + enhanced stats ===
 
-	// Horizontal flex for CPU and MEM sparklines side by side
-	graphFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
-		AddItem(p.cpuView, 0, 1, false).
-		AddItem(p.memView, 0, 1, false)
+		// Network and Disk sparkline views
+		p.netView = p.createSparklineView()
+		p.diskView = p.createSparklineView()
 
-	// Flex layout: stacks bordered stats and graph vertically
-	p.root = tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(p.statsView, 3, 0, false). // 3 rows (1 content + 2 border)
-		AddItem(graphFlex, 0, 1, false)    // remaining for sparklines
+		// All 4 sparklines side-by-side, each 25% width
+		graphFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
+			AddItem(p.cpuView, 0, 1, false).  // 25%
+			AddItem(p.memView, 0, 1, false).  // 25%
+			AddItem(p.netView, 0, 1, false).  // 25%
+			AddItem(p.diskView, 0, 1, false)  // 25%
+
+		// Enhanced stats row
+		p.enhancedStats = tview.NewTextView()
+		p.enhancedStats.SetDynamicColors(true)
+		p.enhancedStats.SetBorder(true)
+		p.enhancedStats.SetBorderPadding(0, 0, 0, 0)
+
+		// Full layout: stats + 4 sparklines + enhanced stats
+		p.root = tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(p.statsView, 3, 0, false).     // Stats row (3 rows with border)
+			AddItem(graphFlex, 0, 1, false).       // 4 sparklines (flexible)
+			AddItem(p.enhancedStats, 3, 0, false)  // Enhanced stats (3 rows with border)
+	} else {
+		// === METRICS SERVER LAYOUT: 2 sparklines ===
+
+		// Horizontal flex for CPU and MEM sparklines side by side
+		graphFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
+			AddItem(p.cpuView, 0, 1, false). // 50%
+			AddItem(p.memView, 0, 1, false)  // 50%
+
+		// Flex layout: stacks bordered stats and graph vertically
+		p.root = tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(p.statsView, 3, 0, false). // 3 rows (1 content + 2 border)
+			AddItem(graphFlex, 0, 1, false)    // remaining for sparklines
+	}
+
 	p.root.SetBorder(true)
 	p.root.SetBorderPadding(0, 0, 0, 0)
 	p.root.SetTitle(p.GetTitle())
@@ -84,8 +134,14 @@ func (p *clusterSummaryPanel) DrawBody(data interface{}) {
 	}
 
 	colorKeys := ui.ColorKeys{0: "olivedrab", 40: "yellow", 80: "red"}
-	const sparklineHeight = 5 // 7 graphFlex rows - 2 border rows = 5 (label moved to title)
-	const defaultWidth = 40   // Initial width before container dimensions are known
+	const defaultWidth = 40 // Initial width before container dimensions are known
+
+	// Sparkline height - use actual view height (minus 2 for border)
+	_, _, _, viewHeight := p.cpuView.GetRect()
+	sparklineHeight := viewHeight - 2 // subtract top/bottom border
+	if sparklineHeight < 1 {
+		sparklineHeight = 1
+	}
 
 	switch summary := data.(type) {
 	case model.ClusterSummary:
@@ -94,34 +150,51 @@ func (p *clusterSummaryPanel) DrawBody(data interface{}) {
 		// Check if usage metrics are actually available (non-zero)
 		hasUsageMetrics := summary.UsageNodeCpuTotal.MilliValue() > 0 || summary.UsageNodeMemTotal.MilliValue() > 0
 
-		// Initialize multi-line sparklines if needed
-		if p.cpuSparkline == nil {
+		// Initialize multi-line sparklines if needed, or recreate if height changed
+		if p.cpuSparkline == nil || p.cpuSparkline.Height() != sparklineHeight {
 			p.cpuSparkline = ui.NewSparklineStateWithHeight(defaultWidth, sparklineHeight, colorKeys)
 		}
-		if p.memSparkline == nil {
+		if p.memSparkline == nil || p.memSparkline.Height() != sparklineHeight {
 			p.memSparkline = ui.NewSparklineStateWithHeight(defaultWidth, sparklineHeight, colorKeys)
 		}
 
 		// Get container width and resize sparklines to fill available space
-		_, _, containerWidth, _ := p.cpuView.GetRect()
-		if containerWidth > 2 {
-			sparklineWidth := containerWidth - 2 // subtract border chars
-			p.cpuSparkline.Resize(sparklineWidth)
-			p.memSparkline.Resize(sparklineWidth)
+		_, _, cpuContainerWidth, _ := p.cpuView.GetRect()
+		if cpuContainerWidth > 2 {
+			p.cpuSparkline.Resize(cpuContainerWidth - 2)
+		}
+		_, _, memContainerWidth, _ := p.memView.GetRect()
+		if memContainerWidth > 2 {
+			p.memSparkline.Resize(memContainerWidth - 2)
 		}
 
 		// === Stats row ===
-		statsText := fmt.Sprintf(
-			"[yellow]Uptime: [white]%s [yellow]│ Nodes: [white]%d [yellow]│ Pods: [white]%d/%d [yellow]│ Deploys: [white]%d/%d [yellow]│ NS: [white]%d [yellow]│ Jobs: [white]%d [yellow]│ Sets: [white]r%d d%d s%d",
-			duration.HumanDuration(time.Since(summary.Uptime.Time)),
-			summary.NodesReady,
-			summary.PodsRunning, summary.PodsAvailable,
-			summary.DeploymentsReady, summary.DeploymentsTotal,
-			summary.Namespaces,
-			summary.JobsCount,
-			summary.ReplicaSetsReady, summary.DaemonSetsReady, summary.StatefulSetsReady,
-		)
-		p.statsView.SetText(statsText)
+		if p.prometheusMode {
+			// Prometheus mode: show container count instead of jobs/sets
+			statsText := fmt.Sprintf(
+				"[yellow]Uptime: [white]%s [yellow]│ Nodes: [white]%d [yellow]│ Pods: [white]%d/%d [yellow]│ Deploys: [white]%d/%d [yellow]│ NS: [white]%d [yellow]│ Containers: [white]%d",
+				duration.HumanDuration(time.Since(summary.Uptime.Time)),
+				summary.NodesReady,
+				summary.PodsRunning, summary.PodsAvailable,
+				summary.DeploymentsReady, summary.DeploymentsTotal,
+				summary.Namespaces,
+				summary.ContainerCount,
+			)
+			p.statsView.SetText(statsText)
+		} else {
+			// Metrics Server mode: original stats
+			statsText := fmt.Sprintf(
+				"[yellow]Uptime: [white]%s [yellow]│ Nodes: [white]%d [yellow]│ Pods: [white]%d/%d [yellow]│ Deploys: [white]%d/%d [yellow]│ NS: [white]%d [yellow]│ Jobs: [white]%d [yellow]│ Sets: [white]r%d d%d s%d",
+				duration.HumanDuration(time.Since(summary.Uptime.Time)),
+				summary.NodesReady,
+				summary.PodsRunning, summary.PodsAvailable,
+				summary.DeploymentsReady, summary.DeploymentsTotal,
+				summary.Namespaces,
+				summary.JobsCount,
+				summary.ReplicaSetsReady, summary.DaemonSetsReady, summary.StatefulSetsReady,
+			)
+			p.statsView.SetText(statsText)
+		}
 
 		// === CPU and MEM sparklines ===
 		var cpuValue, cpuTotal int64
@@ -171,11 +244,129 @@ func (p *clusterSummaryPanel) DrawBody(data interface{}) {
 		memTitle := fmt.Sprintf(" MEM %s/%s (%02.1f%% %s) %s ",
 			memValue, memTotal, memRatio*100, memLabel, memTrend)
 		p.memView.SetTitle(memTitle)
-		p.memView.SetText(memSparklineText) // This is correct - memSparklineText
+		p.memView.SetText(memSparklineText)
+
+		// === Prometheus-only: Network, Disk, Enhanced Stats ===
+		if p.prometheusMode {
+			p.drawNetworkSparkline(summary, sparklineHeight, colorKeys)
+			p.drawDiskSparkline(summary, sparklineHeight, colorKeys)
+			p.drawEnhancedStats(summary)
+		}
 
 	default:
 		panic(fmt.Sprintf("SummaryPanel.DrawBody: unexpected type %T", data))
 	}
+}
+
+// drawNetworkSparkline renders the network I/O sparkline (Prometheus mode only)
+func (p *clusterSummaryPanel) drawNetworkSparkline(summary model.ClusterSummary, height int, colorKeys ui.ColorKeys) {
+	if p.netView == nil {
+		return
+	}
+
+	const defaultWidth = 40
+
+	// Initialize sparkline if needed, or recreate if height changed
+	if p.netSparkline == nil || p.netSparkline.Height() != height {
+		p.netSparkline = ui.NewSparklineStateWithHeight(defaultWidth, height, colorKeys)
+	}
+
+	// Resize to fit container
+	_, _, containerWidth, _ := p.netView.GetRect()
+	if containerWidth > 2 {
+		p.netSparkline.Resize(containerWidth - 2)
+	}
+
+	// Format title with rates
+	netTitle := fmt.Sprintf(" Net ↓%s ↑%s ",
+		ui.FormatBytesRate(summary.NetworkRxRate),
+		ui.FormatBytesRate(summary.NetworkTxRate))
+	p.netView.SetTitle(netTitle)
+
+	// Normalize combined rate (against 1 Gbps baseline = 128 MB/s)
+	combinedRate := summary.NetworkRxRate + summary.NetworkTxRate
+	normalized := combinedRate / (128 * 1024 * 1024) // 128 MB/s baseline
+	if normalized > 1 {
+		normalized = 1
+	}
+	p.netSparkline.Push(normalized)
+	p.netView.SetText(p.netSparkline.Render())
+}
+
+// drawDiskSparkline renders the disk I/O sparkline (Prometheus mode only)
+func (p *clusterSummaryPanel) drawDiskSparkline(summary model.ClusterSummary, height int, colorKeys ui.ColorKeys) {
+	if p.diskView == nil {
+		return
+	}
+
+	const defaultWidth = 40
+
+	// Initialize sparkline if needed, or recreate if height changed
+	if p.diskSparkline == nil || p.diskSparkline.Height() != height {
+		p.diskSparkline = ui.NewSparklineStateWithHeight(defaultWidth, height, colorKeys)
+	}
+
+	// Resize to fit container
+	_, _, containerWidth, _ := p.diskView.GetRect()
+	if containerWidth > 2 {
+		p.diskSparkline.Resize(containerWidth - 2)
+	}
+
+	// Format title with rates
+	diskTitle := fmt.Sprintf(" Disk R:%s W:%s ",
+		ui.FormatBytesRate(summary.DiskReadRate),
+		ui.FormatBytesRate(summary.DiskWriteRate))
+	p.diskView.SetTitle(diskTitle)
+
+	// Normalize combined rate (against 500 MB/s baseline)
+	combinedRate := summary.DiskReadRate + summary.DiskWriteRate
+	normalized := combinedRate / (500 * 1024 * 1024) // 500 MB/s baseline
+	if normalized > 1 {
+		normalized = 1
+	}
+	p.diskSparkline.Push(normalized)
+	p.diskView.SetText(p.diskSparkline.Render())
+}
+
+// drawEnhancedStats renders the enhanced stats row (Prometheus mode only)
+func (p *clusterSummaryPanel) drawEnhancedStats(summary model.ClusterSummary) {
+	if p.enhancedStats == nil {
+		return
+	}
+
+	// Color-code health indicators
+	restartsColor := "green"
+	if summary.ContainerRestarts1h > 10 {
+		restartsColor = "red"
+	} else if summary.ContainerRestarts1h > 5 {
+		restartsColor = "yellow"
+	}
+
+	oomColor := "green"
+	if summary.OOMKillCount > 0 {
+		oomColor = "red"
+	}
+
+	pressureColor := "green"
+	if summary.NodePressureCount > 0 {
+		pressureColor = "red"
+	}
+
+	throttledColor := "green"
+	if summary.CPUThrottledPercent > 20 {
+		throttledColor = "red"
+	} else if summary.CPUThrottledPercent > 10 {
+		throttledColor = "yellow"
+	}
+
+	enhancedText := fmt.Sprintf(
+		"[yellow]Restarts: [%s]%d (1h)[yellow] │ OOMKills: [%s]%d[yellow] │ Pressure: [%s]%d[yellow] │ Throttled: [%s]%.1f%%",
+		restartsColor, summary.ContainerRestarts1h,
+		oomColor, summary.OOMKillCount,
+		pressureColor, summary.NodePressureCount,
+		throttledColor, summary.CPUThrottledPercent,
+	)
+	p.enhancedStats.SetText(enhancedText)
 }
 
 func (p *clusterSummaryPanel) DrawFooter(data interface{}) {}


### PR DESCRIPTION
Update the Cluster Summary to include new graph and info from  Prometheus
- Dynamic 4-sparkline layout for Prometheus mode
  - cAdvisor metrics for Network/Disk I/O
  - Dynamic sparkline graph height matching view dimensions
  - Enhanced stats row (Restarts, OOMKills, Pressure, Throttled)

Fixes #103 