### PR TITLE
issue-111 - chore: Metrics Source Defaults to Prometheus

### DIFF
--- a/hack/deploy/README.md
+++ b/hack/deploy/README.md
@@ -1,0 +1,165 @@
+# ktop Test Users and RBAC
+
+This directory contains RBAC configurations for testing ktop with different permission levels.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `ktop-user.yaml` | Two test service accounts with different access levels |
+| `generate-minikube-kubeconfig.sh` | Helper script to generate kubeconfig for minikube |
+| `rbac-prometheus.yaml` | ClusterRole for Prometheus scraping (reference) |
+
+## Test Users
+
+The `ktop-user.yaml` creates two service accounts for testing metrics source fallback:
+
+| User | Prometheus | Metrics-Server | Use Case |
+|------|------------|----------------|----------|
+| `ktop-full` | Yes | Yes | Full access, tests default prometheus path |
+| `ktop-restricted` | No | Yes | Tests fallback from prometheus to metrics-server |
+
+## Setup
+
+### 1. Apply the RBAC configuration
+
+```bash
+kubectl apply -f ktop-user.yaml
+```
+
+### 2. Generate kubeconfig for test users (minikube)
+
+**For ktop-full (full access):**
+
+```bash
+./generate-minikube-kubeconfig.sh ktop-full
+```
+
+**For ktop-restricted (metrics-server only):**
+
+```bash
+./generate-minikube-kubeconfig.sh ktop-restricted
+```
+
+Or manually:
+
+```bash
+# Set the user (ktop-full or ktop-restricted)
+USER=ktop-restricted
+
+# Generate token (valid for 24 hours)
+TOKEN=$(kubectl create token $USER -n ktop-test --duration=24h)
+
+# Get cluster info
+CLUSTER_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CLUSTER_CA=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
+# Create kubeconfig
+cat > /tmp/ktop-${USER}.kubeconfig <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: ${CLUSTER_CA}
+    server: ${CLUSTER_SERVER}
+  name: ktop-test
+contexts:
+- context:
+    cluster: ktop-test
+    user: ${USER}
+    namespace: default
+  name: ${USER}
+current-context: ${USER}
+users:
+- name: ${USER}
+  user:
+    token: ${TOKEN}
+EOF
+
+echo "Created /tmp/ktop-${USER}.kubeconfig"
+```
+
+## Testing Metrics Source Fallback
+
+### Test 1: Full access user (prometheus works)
+
+```bash
+# Should use prometheus successfully
+ktop --kubeconfig=/tmp/ktop-ktop-full.kubeconfig
+
+# Expected output:
+# Connected to: https://...
+# Connecting to Prometheus... ✓
+```
+
+### Test 2: Restricted user with default (fallback to metrics-server)
+
+```bash
+# Should fail prometheus, fallback to metrics-server
+ktop --kubeconfig=/tmp/ktop-ktop-restricted.kubeconfig
+
+# Expected output:
+# Connected to: https://...
+# Connecting to Prometheus... ✗
+# Falling back to Metrics Server... ✓
+```
+
+### Test 3: Restricted user with explicit prometheus (should fail)
+
+```bash
+# Should fail with error (no fallback when explicit)
+ktop --kubeconfig=/tmp/ktop-ktop-restricted.kubeconfig --metrics-source=prometheus
+
+# Expected output:
+# Connected to: https://...
+# Connecting to Prometheus... ✗
+# Error: prometheus not available: ...
+```
+
+### Test 4: Restricted user with explicit metrics-server (should work)
+
+```bash
+# Should work directly
+ktop --kubeconfig=/tmp/ktop-ktop-restricted.kubeconfig --metrics-source=metrics-server
+
+# Expected output:
+# Connected to: https://...
+# Connecting to Metrics Server... ✓
+```
+
+### Test 5: No metrics mode
+
+```bash
+# Should work, shows resource requests/limits only
+ktop --kubeconfig=/tmp/ktop-ktop-restricted.kubeconfig --metrics-source=none
+
+# Expected output:
+# Connected to: https://...
+# Using metrics source: None
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f ktop-user.yaml
+rm /tmp/ktop-ktop-*.kubeconfig
+```
+
+## RBAC Permissions Reference
+
+### Prometheus scraping requires
+
+| Resource | API Group | Verbs | Purpose |
+|----------|-----------|-------|---------|
+| `nodes` | `""` | get, list | Node discovery |
+| `nodes/proxy` | `""` | get | Kubelet/cAdvisor metrics via `/api/v1/nodes/{node}/proxy/metrics` |
+| `pods` | `""` | get, list | Pod discovery |
+| `pods/proxy` | `""` | get | Component metrics via `/api/v1/namespaces/{ns}/pods/{pod}/proxy/metrics` |
+| `/metrics` | (non-resource) | get | API server metrics |
+
+### Metrics-server requires
+
+| Resource | API Group | Verbs | Purpose |
+|----------|-----------|-------|---------|
+| `nodes` | `metrics.k8s.io` | get, list | Node metrics |
+| `pods` | `metrics.k8s.io` | get, list | Pod metrics |

--- a/hack/deploy/generate-minikube-kubeconfig.sh
+++ b/hack/deploy/generate-minikube-kubeconfig.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Generate a kubeconfig file for ktop test users
+#
+# Usage:
+#   ./generate-kubeconfig.sh <user>
+#
+# Examples:
+#   ./generate-kubeconfig.sh ktop-full
+#   ./generate-kubeconfig.sh ktop-restricted
+#
+
+set -e
+
+USER=${1:-}
+
+if [ -z "$USER" ]; then
+    echo "Usage: $0 <user>"
+    echo ""
+    echo "Available users:"
+    echo "  ktop-full       - Full access (prometheus + metrics-server)"
+    echo "  ktop-restricted - Restricted access (metrics-server only)"
+    exit 1
+fi
+
+NAMESPACE="ktop-test"
+OUTPUT_FILE="/tmp/ktop-${USER}.kubeconfig"
+
+# Verify the service account exists
+if ! kubectl get serviceaccount "$USER" -n "$NAMESPACE" &>/dev/null; then
+    echo "Error: ServiceAccount '$USER' not found in namespace '$NAMESPACE'"
+    echo ""
+    echo "Did you apply the RBAC configuration?"
+    echo "  kubectl apply -f ktop-user.yaml"
+    exit 1
+fi
+
+echo "Generating kubeconfig for $USER..."
+
+# Generate token (valid for 24 hours)
+TOKEN=$(kubectl create token "$USER" -n "$NAMESPACE" --duration=24h)
+
+# Get cluster info
+CLUSTER_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+
+# Try to get embedded CA data first, fall back to reading from file (minikube)
+CLUSTER_CA=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+if [ -z "$CLUSTER_CA" ]; then
+    CA_FILE=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+    if [ -n "$CA_FILE" ] && [ -f "$CA_FILE" ]; then
+        CLUSTER_CA=$(base64 -w 0 < "$CA_FILE")
+    else
+        echo "Error: Could not find cluster CA certificate"
+        exit 1
+    fi
+fi
+
+# Create kubeconfig
+cat > "$OUTPUT_FILE" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: ${CLUSTER_CA}
+    server: ${CLUSTER_SERVER}
+  name: ktop-test
+contexts:
+- context:
+    cluster: ktop-test
+    user: ${USER}
+    namespace: default
+  name: ${USER}
+current-context: ${USER}
+users:
+- name: ${USER}
+  user:
+    token: ${TOKEN}
+EOF
+
+echo "Created: $OUTPUT_FILE"
+echo ""
+echo "Test with:"
+echo "  ktop --kubeconfig=$OUTPUT_FILE"

--- a/hack/deploy/ktop-user.yaml
+++ b/hack/deploy/ktop-user.yaml
@@ -1,35 +1,118 @@
+# ktop Test Users
+#
+# This file creates two service accounts for testing ktop:
+#   1. ktop-full - Full access including Prometheus scraping (nodes/proxy)
+#   2. ktop-restricted - Only metrics-server access (no nodes/proxy)
+#
+# Usage:
+#   kubectl apply -f ktop-user.yaml
+#
+# See README.md for kubeconfig generation instructions.
+
+---
+# Namespace for test users
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ktop-test
+
+---
+# =============================================================================
+# FULL ACCESS USER - Can use both Prometheus and metrics-server
+# =============================================================================
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ktopuser
-  namespace: default
+  name: ktop-full
+  namespace: ktop-test
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  name: ktopuser-role
-  namespace: default
-rules:          # Authorization rules for this role
-  - apiGroups:  # 1st API group
-      - ''      # An empty string designates the core API group.
-    resources:
-      - services
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
+  name: ktop-full-access
+rules:
+# Basic Kubernetes resources
+- apiGroups: [""]
+  resources: ["pods", "nodes", "namespaces", "services", "persistentvolumes", "persistentvolumeclaims", "events"]
+  verbs: ["get", "list", "watch"]
+# Deployments and other workloads
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+# Metrics-server access
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+# Prometheus scraping - nodes/proxy (required for kubelet/cAdvisor metrics)
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+# Prometheus scraping - pods/proxy (required for etcd, scheduler, controller-manager)
+- apiGroups: [""]
+  resources: ["pods/proxy"]
+  verbs: ["get"]
+# API server metrics endpoint
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: ktopuser-role-binding
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ktopuser-role
+  name: ktop-full-access-binding
 subjects:
-  - kind: User
-    name: ktopuser
-    namespace: default
+- kind: ServiceAccount
+  name: ktop-full
+  namespace: ktop-test
+roleRef:
+  kind: ClusterRole
+  name: ktop-full-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# =============================================================================
+# RESTRICTED USER - Only metrics-server, NO Prometheus scraping
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ktop-restricted
+  namespace: ktop-test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ktop-metrics-server-only
+rules:
+# Basic Kubernetes resources
+- apiGroups: [""]
+  resources: ["pods", "nodes", "namespaces", "services", "persistentvolumes", "persistentvolumeclaims", "events"]
+  verbs: ["get", "list", "watch"]
+# Deployments and other workloads
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+# Metrics-server access
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+# NOTE: Explicitly NO access to:
+#   - nodes/proxy (required for Prometheus kubelet/cAdvisor scraping)
+#   - pods/proxy (required for Prometheus component scraping)
+#   - /metrics (API server metrics)
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ktop-metrics-server-only-binding
+subjects:
+- kind: ServiceAccount
+  name: ktop-restricted
+  namespace: ktop-test
+roleRef:
+  kind: ClusterRole
+  name: ktop-metrics-server-only
+  apiGroup: rbac.authorization.k8s.io

--- a/metrics/prom/prom_source.go
+++ b/metrics/prom/prom_source.go
@@ -110,6 +110,12 @@ func (p *PromMetricsSource) Stop() error {
 	return p.controller.Stop()
 }
 
+// TestConnection performs a test scrape to verify connectivity and permissions.
+// Returns nil if the prometheus endpoints are accessible.
+func (p *PromMetricsSource) TestConnection(ctx context.Context) error {
+	return p.controller.TestScrape(ctx)
+}
+
 // calculateCPURate calculates CPU usage rate from counter samples over a time window
 // Returns CPU cores (e.g., 0.1 = 100 millicores)
 // Uses silent fallback - returns error without logging on insufficient samples


### PR DESCRIPTION
  - Default changed: --metrics-source now defaults to prometheus instead of metrics-server
  - Automatic fallback: When not explicitly set, tries prometheus → metrics-server → none
  - No fallback when explicit: --metrics-source=prometheus fails if prometheus unavailable
  - Alias support: --metrics-source=prom works as shorthand
  - Startup progress: Shows connection attempts (✓/✗) and fallback status

Fixes #111 