### PR TITLE
issue-113 - chore: Polish Pod Resource Detail View

### DIFF
--- a/application/app_ui.go
+++ b/application/app_ui.go
@@ -162,6 +162,21 @@ func (p *appPanel) switchToPage(title string) {
 	p.pages.SwitchToPage(title)
 }
 
+// addDetailPage adds a detail page that can be shown when navigating to resources
+func (p *appPanel) addDetailPage(name string, page tview.Primitive) {
+	p.pages.AddPage(name, page, true, false)
+}
+
+// showDetailPage switches to a detail page
+func (p *appPanel) showDetailPage(name string) {
+	p.pages.SwitchToPage(name)
+}
+
+// getPagesWidget returns the pages widget for external access
+func (p *appPanel) getPagesWidget() *tview.Pages {
+	return p.pages
+}
+
 func (p *appPanel) showModalView(t tview.Primitive) {
 	p.tviewApp.SetRoot(t, false)
 }

--- a/application/navigation.go
+++ b/application/navigation.go
@@ -1,0 +1,97 @@
+package application
+
+// PageType represents the type of page in the navigation stack
+type PageType string
+
+const (
+	PageOverview    PageType = "overview"
+	PageNodeDetail  PageType = "node_detail"
+	PagePodDetail   PageType = "pod_detail"
+)
+
+// PageState represents a page in the navigation stack
+type PageState struct {
+	PageType   PageType
+	ResourceID string // e.g., "minikube" for node, "kube-system/coredns-xyz" for pod
+	ScrollPos  int    // Scroll position to restore when navigating back
+}
+
+// NavigationStack manages page navigation history
+type NavigationStack struct {
+	stack []PageState
+}
+
+// NewNavigationStack creates a new navigation stack with the overview as the initial page
+func NewNavigationStack() *NavigationStack {
+	return &NavigationStack{
+		stack: []PageState{
+			{PageType: PageOverview},
+		},
+	}
+}
+
+// Push adds a new page to the stack
+func (n *NavigationStack) Push(state PageState) {
+	n.stack = append(n.stack, state)
+}
+
+// Pop removes and returns the top page from the stack
+// Returns nil if only the root page (overview) remains
+func (n *NavigationStack) Pop() *PageState {
+	if len(n.stack) <= 1 {
+		return nil // Can't pop the root page
+	}
+	// Remove and return the last item
+	lastIdx := len(n.stack) - 1
+	popped := n.stack[lastIdx]
+	n.stack = n.stack[:lastIdx]
+	return &popped
+}
+
+// Current returns the current (top) page state
+func (n *NavigationStack) Current() *PageState {
+	if len(n.stack) == 0 {
+		return nil
+	}
+	return &n.stack[len(n.stack)-1]
+}
+
+// Previous returns the previous page state (one below current)
+// Returns nil if at the root page
+func (n *NavigationStack) Previous() *PageState {
+	if len(n.stack) <= 1 {
+		return nil
+	}
+	return &n.stack[len(n.stack)-2]
+}
+
+// CanGoBack returns true if there's a page to go back to
+func (n *NavigationStack) CanGoBack() bool {
+	return len(n.stack) > 1
+}
+
+// Depth returns the current stack depth
+func (n *NavigationStack) Depth() int {
+	return len(n.stack)
+}
+
+// Clear resets the stack to just the overview page
+func (n *NavigationStack) Clear() {
+	n.stack = []PageState{
+		{PageType: PageOverview},
+	}
+}
+
+// UpdateCurrentScrollPos updates the scroll position of the current page
+func (n *NavigationStack) UpdateCurrentScrollPos(scrollPos int) {
+	if len(n.stack) > 0 {
+		n.stack[len(n.stack)-1].ScrollPos = scrollPos
+	}
+}
+
+// Breadcrumb returns a slice of page states representing the navigation path
+func (n *NavigationStack) Breadcrumb() []PageState {
+	result := make([]PageState, len(n.stack))
+	copy(result, n.stack)
+	return result
+}

--- a/k8s/client_controller.go
+++ b/k8s/client_controller.go
@@ -32,6 +32,7 @@ type Controller struct {
 	podInformer         coreV1Informers.PodInformer
 	pvInformer          coreV1Informers.PersistentVolumeInformer
 	pvcInformer         coreV1Informers.PersistentVolumeClaimInformer
+	eventInformer       coreV1Informers.EventInformer
 
 	jobInformer     batchV1Informers.JobInformer
 	cronJobInformer batchV1Informers.CronJobInformer
@@ -131,6 +132,8 @@ func (c *Controller) Start(ctx context.Context, resync time.Duration) error {
 	pvHasSynced := c.pvInformer.Informer().HasSynced
 	c.pvcInformer = coreInformers.PersistentVolumeClaims()
 	pvcHasSynced := c.pvcInformer.Informer().HasSynced
+	c.eventInformer = coreInformers.Events()
+	eventHasSynced := c.eventInformer.Informer().HasSynced
 
 	// Apps/v1 Informers
 	appsInformers := factory.Apps().V1()
@@ -172,6 +175,7 @@ func (c *Controller) Start(ctx context.Context, resync time.Duration) error {
 		ok := cache.WaitForCacheSync(ctx.Done(),
 			pvHasSynced,
 			pvcHasSynced,
+			eventHasSynced,
 			deploymentHasSynced,
 			daemonsetHasSynced,
 			replicasetHasSynced,

--- a/k8s/client_funcs.go
+++ b/k8s/client_funcs.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"sort"
 
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"
@@ -117,4 +118,74 @@ func (c *Controller) GetPVCList(ctx context.Context) ([]*coreV1.PersistentVolume
 		return nil, err
 	}
 	return items, nil
+}
+
+// GetEventsForNode returns events related to a specific node
+func (c *Controller) GetEventsForNode(ctx context.Context, nodeName string) ([]coreV1.Event, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Events for nodes are cluster-scoped, so we list all events and filter
+	allEvents, err := c.eventInformer.Lister().List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	var nodeEvents []coreV1.Event
+	for _, evt := range allEvents {
+		if evt.InvolvedObject.Kind == "Node" && evt.InvolvedObject.Name == nodeName {
+			nodeEvents = append(nodeEvents, *evt)
+		}
+	}
+
+	// Sort by LastTimestamp descending (most recent first)
+	sortEventsByTime(nodeEvents)
+	return nodeEvents, nil
+}
+
+// GetEventsForPod returns events related to a specific pod
+func (c *Controller) GetEventsForPod(ctx context.Context, namespace, podName string) ([]coreV1.Event, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Get events from the pod's namespace
+	allEvents, err := c.eventInformer.Lister().Events(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	var podEvents []coreV1.Event
+	for _, evt := range allEvents {
+		if evt.InvolvedObject.Kind == "Pod" && evt.InvolvedObject.Name == podName {
+			podEvents = append(podEvents, *evt)
+		}
+	}
+
+	// Sort by LastTimestamp descending (most recent first)
+	sortEventsByTime(podEvents)
+	return podEvents, nil
+}
+
+// sortEventsByTime sorts events by LastTimestamp descending (most recent first)
+// Uses stable sort with secondary key (event name) for deterministic ordering
+func sortEventsByTime(events []coreV1.Event) {
+	sort.SliceStable(events, func(i, j int) bool {
+		timeI := events[i].LastTimestamp.Time
+		timeJ := events[j].LastTimestamp.Time
+		// If LastTimestamp is zero, use EventTime
+		if timeI.IsZero() && !events[i].EventTime.IsZero() {
+			timeI = events[i].EventTime.Time
+		}
+		if timeJ.IsZero() && !events[j].EventTime.IsZero() {
+			timeJ = events[j].EventTime.Time
+		}
+		// Sort descending (most recent first)
+		// If times are equal, sort by name for stability
+		if timeI.Equal(timeJ) {
+			return events[i].Name < events[j].Name
+		}
+		return timeI.After(timeJ)
+	})
 }

--- a/k8s/nodes_controller.go
+++ b/k8s/nodes_controller.go
@@ -20,7 +20,8 @@ func (c *Controller) GetNode(ctx context.Context, nodeName string) (*coreV1.Node
 	if err != nil {
 		return nil, err
 	}
-	return node, nil
+	// Return a deep copy to avoid pointer to informer cache issues
+	return node.DeepCopy(), nil
 }
 
 func (c *Controller) GetNodeList(ctx context.Context) ([]*coreV1.Node, error) {

--- a/views/model/node_detail_data.go
+++ b/views/model/node_detail_data.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeDetailData contains all data needed to display a node detail view
+type NodeDetailData struct {
+	// NodeModel contains the basic node metrics and info
+	NodeModel *NodeModel
+
+	// Node is the full Kubernetes Node object for accessing labels, conditions, etc.
+	Node *corev1.Node
+
+	// PodsOnNode is the list of pods running on this node
+	PodsOnNode []*PodModel
+
+	// Events are recent Kubernetes events for this node
+	Events []corev1.Event
+
+	// MetricsHistory contains historical CPU/memory samples for sparkline graphs
+	MetricsHistory []MetricSample
+}
+
+// MetricSample represents a single point in time for metrics history
+type MetricSample struct {
+	Timestamp int64   // Unix timestamp
+	CPURatio  float64 // CPU usage as ratio 0-1
+	MemRatio  float64 // Memory usage as ratio 0-1
+}
+
+// NodeConditionInfo provides a structured view of a node condition
+type NodeConditionInfo struct {
+	Type    string
+	Status  string
+	Reason  string
+	Message string
+	Healthy bool
+}
+
+// GetConditions returns structured condition information from the node
+func (d *NodeDetailData) GetConditions() []NodeConditionInfo {
+	if d.Node == nil {
+		return nil
+	}
+
+	conditions := make([]NodeConditionInfo, 0, len(d.Node.Status.Conditions))
+	for _, cond := range d.Node.Status.Conditions {
+		// Determine if condition is healthy
+		// Ready=True is healthy, all pressure conditions True are unhealthy
+		healthy := false
+		switch cond.Type {
+		case corev1.NodeReady:
+			healthy = cond.Status == corev1.ConditionTrue
+		case corev1.NodeMemoryPressure, corev1.NodeDiskPressure, corev1.NodePIDPressure:
+			healthy = cond.Status == corev1.ConditionFalse
+		default:
+			healthy = cond.Status == corev1.ConditionFalse
+		}
+
+		conditions = append(conditions, NodeConditionInfo{
+			Type:    string(cond.Type),
+			Status:  string(cond.Status),
+			Reason:  cond.Reason,
+			Message: cond.Message,
+			Healthy: healthy,
+		})
+	}
+	return conditions
+}
+
+// GetLabels returns node labels as a map
+func (d *NodeDetailData) GetLabels() map[string]string {
+	if d.Node == nil {
+		return nil
+	}
+	return d.Node.Labels
+}
+
+// GetAnnotations returns node annotations as a map
+func (d *NodeDetailData) GetAnnotations() map[string]string {
+	if d.Node == nil {
+		return nil
+	}
+	return d.Node.Annotations
+}
+
+// GetTaints returns node taints
+func (d *NodeDetailData) GetTaints() []corev1.Taint {
+	if d.Node == nil {
+		return nil
+	}
+	return d.Node.Spec.Taints
+}
+
+// GetCapacity returns node capacity resources
+func (d *NodeDetailData) GetCapacity() corev1.ResourceList {
+	if d.Node == nil {
+		return nil
+	}
+	return d.Node.Status.Capacity
+}
+
+// GetAllocatable returns node allocatable resources
+func (d *NodeDetailData) GetAllocatable() corev1.ResourceList {
+	if d.Node == nil {
+		return nil
+	}
+	return d.Node.Status.Allocatable
+}

--- a/views/model/pod_detail_data.go
+++ b/views/model/pod_detail_data.go
@@ -1,0 +1,303 @@
+package model
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodDetailData contains all data needed to display a pod detail view
+type PodDetailData struct {
+	// PodModel contains the basic pod metrics and info
+	PodModel *PodModel
+
+	// Pod is the full Kubernetes Pod object
+	Pod *corev1.Pod
+
+	// Events are recent Kubernetes events for this pod
+	Events []corev1.Event
+
+	// MetricsHistory contains historical CPU/memory samples for sparkline graphs
+	// Key is container name
+	MetricsHistory map[string][]MetricSample
+}
+
+// ContainerInfo provides structured container information
+type ContainerInfo struct {
+	Name         string
+	Image        string
+	State        string
+	Ready        bool
+	RestartCount int32
+	Started      bool
+
+	// Resource requests and limits
+	CPURequest    string
+	CPULimit      string
+	MemoryRequest string
+	MemoryLimit   string
+
+	// Probes
+	LivenessProbe  string
+	ReadinessProbe string
+	StartupProbe   string
+}
+
+// PodConditionInfo provides structured pod condition information
+type PodConditionInfo struct {
+	Type    string
+	Status  string
+	Reason  string
+	Message string
+	Healthy bool
+}
+
+// VolumeInfo provides structured volume information
+type VolumeInfo struct {
+	Name      string
+	Type      string
+	MountPath string
+	ReadOnly  bool
+}
+
+// GetContainers returns structured container information
+func (d *PodDetailData) GetContainers() []ContainerInfo {
+	if d.Pod == nil {
+		return nil
+	}
+
+	containers := make([]ContainerInfo, 0, len(d.Pod.Spec.Containers))
+
+	// Build a map of container statuses by name
+	statusMap := make(map[string]corev1.ContainerStatus)
+	for _, status := range d.Pod.Status.ContainerStatuses {
+		statusMap[status.Name] = status
+	}
+
+	for _, container := range d.Pod.Spec.Containers {
+		info := ContainerInfo{
+			Name:  container.Name,
+			Image: container.Image,
+		}
+
+		// Get container status
+		if status, ok := statusMap[container.Name]; ok {
+			info.Ready = status.Ready
+			info.RestartCount = status.RestartCount
+			if status.Started != nil {
+				info.Started = *status.Started
+			}
+
+			// Determine state
+			if status.State.Running != nil {
+				info.State = "Running"
+			} else if status.State.Waiting != nil {
+				info.State = status.State.Waiting.Reason
+				if info.State == "" {
+					info.State = "Waiting"
+				}
+			} else if status.State.Terminated != nil {
+				info.State = status.State.Terminated.Reason
+				if info.State == "" {
+					info.State = "Terminated"
+				}
+			}
+		}
+
+		// Resource requests
+		if cpu := container.Resources.Requests.Cpu(); cpu != nil && !cpu.IsZero() {
+			info.CPURequest = cpu.String()
+		}
+		if mem := container.Resources.Requests.Memory(); mem != nil && !mem.IsZero() {
+			info.MemoryRequest = mem.String()
+		}
+
+		// Resource limits
+		if cpu := container.Resources.Limits.Cpu(); cpu != nil && !cpu.IsZero() {
+			info.CPULimit = cpu.String()
+		}
+		if mem := container.Resources.Limits.Memory(); mem != nil && !mem.IsZero() {
+			info.MemoryLimit = mem.String()
+		}
+
+		// Probes
+		if container.LivenessProbe != nil {
+			info.LivenessProbe = formatProbe(container.LivenessProbe)
+		}
+		if container.ReadinessProbe != nil {
+			info.ReadinessProbe = formatProbe(container.ReadinessProbe)
+		}
+		if container.StartupProbe != nil {
+			info.StartupProbe = formatProbe(container.StartupProbe)
+		}
+
+		containers = append(containers, info)
+	}
+
+	return containers
+}
+
+// formatProbe returns a string representation of a probe
+func formatProbe(probe *corev1.Probe) string {
+	if probe.HTTPGet != nil {
+		return "http-get " + probe.HTTPGet.Path
+	}
+	if probe.TCPSocket != nil {
+		return "tcp " + probe.TCPSocket.Port.String()
+	}
+	if probe.Exec != nil {
+		if len(probe.Exec.Command) > 0 {
+			return "exec " + probe.Exec.Command[0]
+		}
+		return "exec"
+	}
+	if probe.GRPC != nil {
+		if probe.GRPC.Service != nil {
+			return "grpc " + *probe.GRPC.Service
+		}
+		return "grpc"
+	}
+	return ""
+}
+
+// GetConditions returns structured pod condition information
+func (d *PodDetailData) GetConditions() []PodConditionInfo {
+	if d.Pod == nil {
+		return nil
+	}
+
+	conditions := make([]PodConditionInfo, 0, len(d.Pod.Status.Conditions))
+	for _, cond := range d.Pod.Status.Conditions {
+		healthy := cond.Status == corev1.ConditionTrue
+
+		conditions = append(conditions, PodConditionInfo{
+			Type:    string(cond.Type),
+			Status:  string(cond.Status),
+			Reason:  cond.Reason,
+			Message: cond.Message,
+			Healthy: healthy,
+		})
+	}
+	return conditions
+}
+
+// GetVolumes returns structured volume information
+func (d *PodDetailData) GetVolumes() []VolumeInfo {
+	if d.Pod == nil {
+		return nil
+	}
+
+	// Build a map of volume name to volume for lookup
+	volumeMap := make(map[string]corev1.Volume)
+	for _, vol := range d.Pod.Spec.Volumes {
+		volumeMap[vol.Name] = vol
+	}
+
+	// Build volume info from volume mounts
+	var volumes []VolumeInfo
+	seen := make(map[string]bool)
+
+	for _, container := range d.Pod.Spec.Containers {
+		for _, mount := range container.VolumeMounts {
+			if seen[mount.Name] {
+				continue
+			}
+			seen[mount.Name] = true
+
+			info := VolumeInfo{
+				Name:      mount.Name,
+				MountPath: mount.MountPath,
+				ReadOnly:  mount.ReadOnly,
+			}
+
+			// Determine volume type
+			if vol, ok := volumeMap[mount.Name]; ok {
+				info.Type = getVolumeType(vol)
+			}
+
+			volumes = append(volumes, info)
+		}
+	}
+
+	return volumes
+}
+
+// getVolumeType returns a string describing the volume type
+func getVolumeType(vol corev1.Volume) string {
+	switch {
+	case vol.ConfigMap != nil:
+		return "ConfigMap"
+	case vol.Secret != nil:
+		return "Secret"
+	case vol.PersistentVolumeClaim != nil:
+		return "PVC"
+	case vol.EmptyDir != nil:
+		return "EmptyDir"
+	case vol.HostPath != nil:
+		return "HostPath"
+	case vol.Projected != nil:
+		return "Projected"
+	case vol.DownwardAPI != nil:
+		return "DownwardAPI"
+	case vol.NFS != nil:
+		return "NFS"
+	case vol.CSI != nil:
+		return "CSI"
+	default:
+		return "Unknown"
+	}
+}
+
+// GetLabels returns pod labels
+func (d *PodDetailData) GetLabels() map[string]string {
+	if d.Pod == nil {
+		return nil
+	}
+	return d.Pod.Labels
+}
+
+// GetAnnotations returns pod annotations
+func (d *PodDetailData) GetAnnotations() map[string]string {
+	if d.Pod == nil {
+		return nil
+	}
+	return d.Pod.Annotations
+}
+
+// GetOwnerReferences returns owner reference information
+func (d *PodDetailData) GetOwnerReferences() []OwnerReferenceInfo {
+	if d.Pod == nil {
+		return nil
+	}
+
+	refs := make([]OwnerReferenceInfo, 0, len(d.Pod.OwnerReferences))
+	for _, ref := range d.Pod.OwnerReferences {
+		refs = append(refs, OwnerReferenceInfo{
+			Kind:       ref.Kind,
+			Name:       ref.Name,
+			Controller: ref.Controller != nil && *ref.Controller,
+		})
+	}
+	return refs
+}
+
+// OwnerReferenceInfo provides structured owner reference information
+type OwnerReferenceInfo struct {
+	Kind       string
+	Name       string
+	Controller bool
+}
+
+// GetQOSClass returns the pod's QoS class
+func (d *PodDetailData) GetQOSClass() string {
+	if d.Pod == nil {
+		return ""
+	}
+	return string(d.Pod.Status.QOSClass)
+}
+
+// GetServiceAccountName returns the pod's service account name
+func (d *PodDetailData) GetServiceAccountName() string {
+	if d.Pod == nil {
+		return ""
+	}
+	return d.Pod.Spec.ServiceAccountName
+}

--- a/views/node/detail.go
+++ b/views/node/detail.go
@@ -1,0 +1,919 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/vladimirvivien/ktop/ui"
+	"github.com/vladimirvivien/ktop/views/model"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// NodeSelectedCallback is called when a pod is selected in the node detail view
+type NodeSelectedCallback func(namespace, podName string)
+
+// DetailPanel displays detailed information about a node
+type DetailPanel struct {
+	root    *tview.Flex
+	data    *model.NodeDetailData
+	laidout bool
+
+	// Track current node to detect when node changes (for resetting sparklines)
+	currentNodeName string
+
+	// Focus management for tab cycling
+	focusedChildIdx int              // Index of currently focused child (-1 = none)
+	focusableItems  []tview.Primitive // Ordered list of focusable primitives
+	focusablePanels []*tview.Flex     // Corresponding parent panels (for border updates)
+	setAppFocus     func(p tview.Primitive) // Callback to set tview app focus
+
+	// Sub-panels
+	infoHeaderPanel   *tview.Flex
+	sparklinePanel    *tview.Flex
+	systemDetailPanel *tview.Flex
+	eventsPanel       *tview.Flex
+	podsPanel         *tview.Flex
+
+	// Tables
+	leftDetailTable   *tview.Table
+	middleDetailTable *tview.Table
+	eventsTable       *tview.Table
+	podsTable         *tview.Table
+
+	// Text views for labels/annotations (sorted for stable display)
+	labelsTextView      *tview.TextView
+	annotationsTextView *tview.TextView
+
+	// Stateful sparklines for metrics
+	cpuSparkline  *ui.SparklineState
+	memSparkline  *ui.SparklineState
+	netSparkline  *ui.SparklineState
+	diskSparkline *ui.SparklineState
+
+	// Callbacks
+	onPodSelected NodeSelectedCallback
+	onBack        func()
+}
+
+// NewDetailPanel creates a new node detail panel
+func NewDetailPanel() *DetailPanel {
+	p := &DetailPanel{}
+	p.Layout(nil)
+	return p
+}
+
+// SetOnPodSelected sets the callback for when a pod is selected
+func (p *DetailPanel) SetOnPodSelected(callback NodeSelectedCallback) {
+	p.onPodSelected = callback
+}
+
+// SetOnBack sets the callback for when user navigates back
+func (p *DetailPanel) SetOnBack(callback func()) {
+	p.onBack = callback
+}
+
+// GetTitle returns the panel title
+func (p *DetailPanel) GetTitle() string {
+	if p.data != nil && p.data.NodeModel != nil {
+		return fmt.Sprintf("Node: %s", p.data.NodeModel.Name)
+	}
+	return "Node Detail"
+}
+
+// Layout initializes the panel UI
+func (p *DetailPanel) Layout(_ interface{}) {
+	if !p.laidout {
+		colorKeys := ui.ColorKeys{0: "olivedrab", 50: "yellow", 90: "red"}
+
+		// Initialize stateful sparklines (width=20, height=3 for tall multi-line)
+		p.cpuSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+		p.memSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+		p.netSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+		p.diskSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+
+		// Create info header panel
+		p.infoHeaderPanel = tview.NewFlex().SetDirection(tview.FlexColumn)
+		p.infoHeaderPanel.SetBorder(true)
+		p.infoHeaderPanel.SetTitle(" Info ")
+		p.infoHeaderPanel.SetTitleAlign(tview.AlignLeft)
+		p.infoHeaderPanel.SetBorderColor(tcell.ColorWhite)
+
+		// Create sparkline panel (4 columns)
+		p.sparklinePanel = tview.NewFlex().SetDirection(tview.FlexColumn)
+
+		// Create system detail panel (4 columns)
+		p.systemDetailPanel = tview.NewFlex().SetDirection(tview.FlexColumn)
+		p.systemDetailPanel.SetBorder(true)
+		p.systemDetailPanel.SetTitle(" System Detail ")
+		p.systemDetailPanel.SetTitleAlign(tview.AlignLeft)
+		p.systemDetailPanel.SetBorderColor(tcell.ColorWhite)
+
+		// Left column: System info table
+		p.leftDetailTable = tview.NewTable()
+		p.leftDetailTable.SetBorder(false)
+		p.leftDetailTable.SetBorders(false)
+		p.leftDetailTable.SetSelectable(false, false)
+
+		// Middle column: Conditions table
+		p.middleDetailTable = tview.NewTable()
+		p.middleDetailTable.SetBorder(false)
+		p.middleDetailTable.SetBorders(false)
+		p.middleDetailTable.SetSelectable(false, false)
+
+		// Labels column: TextView (scrollable, sorted)
+		p.labelsTextView = tview.NewTextView()
+		p.labelsTextView.SetDynamicColors(true)
+		p.labelsTextView.SetScrollable(true)
+		p.labelsTextView.SetBorder(false)
+
+		// Annotations column: TextView (scrollable, sorted)
+		p.annotationsTextView = tview.NewTextView()
+		p.annotationsTextView.SetDynamicColors(true)
+		p.annotationsTextView.SetScrollable(true)
+		p.annotationsTextView.SetBorder(false)
+
+		p.systemDetailPanel.AddItem(p.leftDetailTable, 0, 1, false)
+		p.systemDetailPanel.AddItem(p.middleDetailTable, 0, 1, false)
+		p.systemDetailPanel.AddItem(p.labelsTextView, 0, 1, false)
+		p.systemDetailPanel.AddItem(p.annotationsTextView, 0, 1, false)
+
+		// Create events panel with table
+		p.eventsPanel = tview.NewFlex().SetDirection(tview.FlexRow)
+		p.eventsPanel.SetBorder(true)
+		p.eventsPanel.SetTitle(" Events ")
+		p.eventsPanel.SetTitleAlign(tview.AlignLeft)
+		p.eventsPanel.SetBorderColor(tcell.ColorWhite)
+
+		p.eventsTable = tview.NewTable()
+		p.eventsTable.SetFixed(1, 0) // Fixed header row
+		p.eventsTable.SetBorder(false)
+		p.eventsTable.SetBorders(false)
+		p.eventsTable.SetSelectable(true, false) // Enable row selection for scrolling
+		p.eventsTable.SetSelectedStyle(tcell.StyleDefault.Background(tcell.ColorYellow).Foreground(tcell.ColorBlue))
+
+		p.eventsPanel.AddItem(p.eventsTable, 0, 1, false)
+
+		// Create pods panel with scrollable table
+		p.podsPanel = tview.NewFlex().SetDirection(tview.FlexRow)
+		p.podsPanel.SetBorder(true)
+		p.podsPanel.SetTitle(" Pods ")
+		p.podsPanel.SetTitleAlign(tview.AlignLeft)
+		p.podsPanel.SetBorderColor(tcell.ColorWhite)
+
+		p.podsTable = tview.NewTable()
+		p.podsTable.SetFixed(1, 0) // Fixed header row
+		p.podsTable.SetSelectable(true, false)
+		p.podsTable.SetBorder(false)
+		p.podsTable.SetBorders(false)
+		p.podsTable.SetSelectedStyle(tcell.StyleDefault.Background(tcell.ColorYellow).Foreground(tcell.ColorBlue))
+
+		// Handle keyboard input on pods table
+		p.podsTable.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyTab:
+				p.cycleFocus()
+				return nil
+			case tcell.KeyBacktab:
+				p.cycleFocusReverse()
+				return nil
+			case tcell.KeyEscape:
+				if p.onBack != nil {
+					p.onBack()
+					return nil
+				}
+			case tcell.KeyEnter:
+				row, _ := p.podsTable.GetSelection()
+				if row > 0 && p.data != nil && row-1 < len(p.data.PodsOnNode) {
+					pod := p.data.PodsOnNode[row-1]
+					if p.onPodSelected != nil {
+						p.onPodSelected(pod.Namespace, pod.Name)
+						return nil
+					}
+				}
+			}
+			return event
+		})
+
+		p.podsPanel.AddItem(p.podsTable, 0, 1, true)
+
+		// Main layout: vertical flex
+		p.root = tview.NewFlex().SetDirection(tview.FlexRow)
+		p.root.AddItem(p.infoHeaderPanel, 3, 0, false)    // Info header: 3 rows
+		p.root.AddItem(p.sparklinePanel, 5, 0, false)     // Sparklines: 5 rows
+		p.root.AddItem(p.systemDetailPanel, 10, 0, false) // System Detail: 10 rows
+		p.root.AddItem(p.eventsPanel, 10, 0, false)       // Events: 10 rows
+		p.root.AddItem(p.podsPanel, 0, 1, true)           // Pods: remaining space (flex)
+
+		p.root.SetBorder(true)
+		p.root.SetTitle(fmt.Sprintf(" %s Node Detail ", ui.Icons.Factory))
+
+		// Set up focusable items for tab cycling
+		// Order: Events -> Pods (the two scrollable/selectable tables)
+		p.focusableItems = []tview.Primitive{p.eventsTable, p.podsTable}
+		p.focusablePanels = []*tview.Flex{p.eventsPanel, p.podsPanel}
+		p.focusedChildIdx = 0 // Start with events focused
+
+		// Set up input capture on root for Tab when page first opens
+		p.root.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyTab:
+				p.cycleFocus()
+				return nil
+			case tcell.KeyBacktab:
+				p.cycleFocusReverse()
+				return nil
+			case tcell.KeyEscape:
+				if p.onBack != nil {
+					p.onBack()
+					return nil
+				}
+			}
+			return event
+		})
+
+		// Set up input capture on events table for Tab and ESC
+		p.eventsTable.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyTab:
+				p.cycleFocus()
+				return nil
+			case tcell.KeyBacktab:
+				p.cycleFocusReverse()
+				return nil
+			case tcell.KeyEscape:
+				if p.onBack != nil {
+					p.onBack()
+					return nil
+				}
+			}
+			return event
+		})
+		p.root.SetTitleAlign(tview.AlignLeft)
+		p.laidout = true
+	}
+}
+
+// DrawHeader draws the header row
+func (p *DetailPanel) DrawHeader(data interface{}) {
+	// Header is part of the layout
+}
+
+// DrawBody draws the main content
+func (p *DetailPanel) DrawBody(data interface{}) {
+	detailData, ok := data.(*model.NodeDetailData)
+	if !ok {
+		return
+	}
+	p.data = detailData
+
+	// Detect if we're viewing a different node - if so, reset sparklines
+	newNodeName := ""
+	if p.data.NodeModel != nil {
+		newNodeName = p.data.NodeModel.Name
+	}
+	if newNodeName != p.currentNodeName {
+		p.resetSparklines()
+		p.currentNodeName = newNodeName
+
+		// Populate sparklines from history if available
+		if len(p.data.MetricsHistory) > 0 {
+			for _, sample := range p.data.MetricsHistory {
+				p.cpuSparkline.Push(sample.CPURatio)
+				p.memSparkline.Push(sample.MemRatio)
+			}
+		}
+	}
+
+	// Update main title with node name and status
+	if p.data.NodeModel != nil {
+		status := p.data.NodeModel.Status
+		statusColor := ui.GetStatusColor(status, "node")
+		p.root.SetTitle(fmt.Sprintf(" %s [::b]Node:[::] %s [%s](%s)[-] ", ui.Icons.Factory, p.data.NodeModel.Name, statusColor, status))
+	}
+
+	p.drawInfoHeader()
+	p.drawSparklines()
+	p.drawSystemDetailSection()
+	p.drawEventsTable()
+	p.drawPodsTable()
+}
+
+// resetSparklines clears all sparkline state for a fresh start
+func (p *DetailPanel) resetSparklines() {
+	colorKeys := ui.ColorKeys{0: "olivedrab", 50: "yellow", 90: "red"}
+	p.cpuSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+	p.memSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+	p.netSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+	p.diskSparkline = ui.NewSparklineStateWithHeight(20, 3, colorKeys)
+}
+
+// drawInfoHeader draws the condensed info header row
+func (p *DetailPanel) drawInfoHeader() {
+	p.infoHeaderPanel.Clear()
+
+	if p.data == nil || p.data.NodeModel == nil {
+		return
+	}
+	node := p.data.NodeModel
+
+	// Get hostname and machineID from raw Node object
+	hostname := "n/a"
+	machineID := "n/a"
+	if p.data.Node != nil {
+		// Get hostname from addresses
+		for _, addr := range p.data.Node.Status.Addresses {
+			if addr.Type == corev1.NodeHostName {
+				hostname = addr.Address
+				break
+			}
+		}
+		// Get machine ID (truncate for display)
+		if p.data.Node.Status.NodeInfo.MachineID != "" {
+			mid := p.data.Node.Status.NodeInfo.MachineID
+			if len(mid) > 12 {
+				machineID = mid[:12] + "..."
+			} else {
+				machineID = mid
+			}
+		}
+	}
+
+	// Build info items
+	items := []string{
+		fmt.Sprintf("[gray]Status:[white] %s", node.Status),
+		fmt.Sprintf("[gray]Roles:[white] %s", strings.Join(node.Roles, ",")),
+		fmt.Sprintf("[gray]Age:[white] %s", node.TimeSinceStart),
+		fmt.Sprintf("[gray]IP:[white] %s", node.InternalIP),
+		fmt.Sprintf("[gray]Hostname:[white] %s", hostname),
+		fmt.Sprintf("[gray]MachineID:[white] %s", machineID),
+	}
+
+	// Create a text view with all items on one line
+	infoText := tview.NewTextView()
+	infoText.SetDynamicColors(true)
+	infoText.SetText("  " + strings.Join(items, "  │  "))
+
+	p.infoHeaderPanel.AddItem(infoText, 0, 1, false)
+}
+
+// drawSparklines draws the 4-column sparkline row
+func (p *DetailPanel) drawSparklines() {
+	p.sparklinePanel.Clear()
+
+	if p.data == nil || p.data.NodeModel == nil {
+		return
+	}
+	node := p.data.NodeModel
+
+	// Update sparkline states with new data
+	var cpuRatio, memRatio float64
+
+	if node.UsageCpuQty != nil && node.AllocatableCpuQty != nil && node.AllocatableCpuQty.MilliValue() > 0 {
+		cpuRatio = float64(node.UsageCpuQty.MilliValue()) / float64(node.AllocatableCpuQty.MilliValue())
+	} else if node.RequestedPodCpuQty != nil && node.AllocatableCpuQty != nil && node.AllocatableCpuQty.MilliValue() > 0 {
+		cpuRatio = float64(node.RequestedPodCpuQty.MilliValue()) / float64(node.AllocatableCpuQty.MilliValue())
+	}
+
+	if node.UsageMemQty != nil && node.AllocatableMemQty != nil && node.AllocatableMemQty.Value() > 0 {
+		memRatio = float64(node.UsageMemQty.Value()) / float64(node.AllocatableMemQty.Value())
+	} else if node.RequestedPodMemQty != nil && node.AllocatableMemQty != nil && node.AllocatableMemQty.Value() > 0 {
+		memRatio = float64(node.RequestedPodMemQty.Value()) / float64(node.AllocatableMemQty.Value())
+	}
+
+	p.cpuSparkline.Push(cpuRatio)
+	p.memSparkline.Push(memRatio)
+	// Network and disk sparklines - push small values so they render (data not available from metrics server)
+	p.netSparkline.Push(0.01) // Small non-zero value to show baseline
+	p.diskSparkline.Push(0.01)
+
+	// Build titles with metrics values (like summary panel)
+	cpuPercent := cpuRatio * 100
+	cpuPercentColor := ui.GetResourcePercentageColor(cpuPercent)
+	cpuTrend := p.cpuSparkline.TrendIndicator(cpuPercent)
+	cpuUsed := "0m"
+	cpuTotal := "0m"
+	if node.UsageCpuQty != nil {
+		cpuUsed = formatCPU(node.UsageCpuQty)
+	}
+	if node.AllocatableCpuQty != nil {
+		cpuTotal = formatCPU(node.AllocatableCpuQty)
+	}
+	cpuTitle := fmt.Sprintf(" CPU %s/%s ([%s]%.1f%% used[-]) %s ", cpuUsed, cpuTotal, cpuPercentColor, cpuPercent, cpuTrend)
+
+	memPercent := memRatio * 100
+	memPercentColor := ui.GetResourcePercentageColor(memPercent)
+	memTrend := p.memSparkline.TrendIndicator(memPercent)
+	memUsed := "0Mi"
+	memTotal := "0Mi"
+	if node.UsageMemQty != nil {
+		memUsed = formatMemory(node.UsageMemQty)
+	}
+	if node.AllocatableMemQty != nil {
+		memTotal = formatMemory(node.AllocatableMemQty)
+	}
+	memTitle := fmt.Sprintf(" MEM %s/%s ([%s]%.1f%% used[-]) %s ", memUsed, memTotal, memPercentColor, memPercent, memTrend)
+
+	// Create 4 sparkline columns with proper formatting
+	cpuPanel := p.createSparklineColumn(cpuTitle, p.cpuSparkline)
+	memPanel := p.createSparklineColumn(memTitle, p.memSparkline)
+	netPanel := p.createSparklineColumn(" NET [gray]↓n/a ↑n/a[-] ", p.netSparkline)
+	diskPanel := p.createSparklineColumn(" DISK [gray]R:n/a W:n/a[-] ", p.diskSparkline)
+
+	p.sparklinePanel.AddItem(cpuPanel, 0, 1, false)
+	p.sparklinePanel.AddItem(memPanel, 0, 1, false)
+	p.sparklinePanel.AddItem(netPanel, 0, 1, false)
+	p.sparklinePanel.AddItem(diskPanel, 0, 1, false)
+}
+
+// createSparklineColumn creates a bordered sparkline column with title containing metrics
+func (p *DetailPanel) createSparklineColumn(title string, sparkline *ui.SparklineState) *tview.Flex {
+	panel := tview.NewFlex().SetDirection(tview.FlexRow)
+	panel.SetBorder(true)
+	panel.SetTitle(title)
+	panel.SetTitleAlign(tview.AlignCenter)
+	panel.SetBorderColor(tcell.ColorWhite)
+
+	// Create text view for sparkline
+	textView := tview.NewTextView()
+	textView.SetDynamicColors(true)
+	textView.SetTextAlign(tview.AlignLeft)
+
+	// Get panel width and resize sparkline to fill available space
+	_, _, panelWidth, _ := p.sparklinePanel.GetInnerRect()
+	if panelWidth > 0 {
+		// Each of 4 panels gets 1/4 of the width, minus borders (2 chars each side)
+		sparklineWidth := (panelWidth / 4) - 4
+		if sparklineWidth > 10 {
+			sparkline.Resize(sparklineWidth)
+		}
+	}
+
+	// Just render the sparkline graph (values are in the title)
+	textView.SetText(sparkline.Render())
+	panel.AddItem(textView, 0, 1, false)
+
+	return panel
+}
+
+// drawSystemDetailSection draws the 4-column system detail section
+func (p *DetailPanel) drawSystemDetailSection() {
+	p.leftDetailTable.Clear()
+	p.middleDetailTable.Clear()
+	p.labelsTextView.Clear()
+	p.annotationsTextView.Clear()
+
+	if p.data == nil || p.data.NodeModel == nil {
+		return
+	}
+	node := p.data.NodeModel
+
+	// === LEFT COLUMN: System Info ===
+	row := 0
+	// Truncate OS to sensible width
+	osImage := node.OSImage
+	if len(osImage) > 35 {
+		osImage = osImage[:32] + "..."
+	}
+	p.addDetailRow(p.leftDetailTable, row, "OS", osImage)
+	row++
+	p.addDetailRow(p.leftDetailTable, row, "Arch", node.Architecture)
+	row++
+	p.addDetailRow(p.leftDetailTable, row, "Kernel", node.OSKernel)
+	row++
+	p.addDetailRow(p.leftDetailTable, row, "Kubelet", node.KubeletVersion)
+	row++
+	p.addDetailRow(p.leftDetailTable, row, "Runtime", node.ContainerRuntimeVersion)
+	row++
+
+	// Pods count
+	maxPods := "n/a"
+	if p.data.Node != nil {
+		if allocPods, ok := p.data.Node.Status.Allocatable[corev1.ResourcePods]; ok {
+			maxPods = allocPods.String()
+		}
+	}
+	p.addDetailRow(p.leftDetailTable, row, "Pods", fmt.Sprintf("%d/%s", node.PodsCount, maxPods))
+	row++
+
+	p.addDetailRow(p.leftDetailTable, row, "Volumes", fmt.Sprintf("%d/%d", node.VolumesInUse, node.VolumesAttached))
+	row++
+
+	// Pod CIDR
+	podCIDR := "n/a"
+	if p.data.Node != nil && p.data.Node.Spec.PodCIDR != "" {
+		podCIDR = p.data.Node.Spec.PodCIDR
+	}
+	p.addDetailRow(p.leftDetailTable, row, "CIDR", podCIDR)
+
+	// === MIDDLE COLUMN: Conditions ===
+	row = 0
+	p.middleDetailTable.SetCell(row, 0, tview.NewTableCell("[::b]Conditions[::-]").SetTextColor(tcell.ColorAqua).SetSelectable(false))
+	row++
+
+	conditions := p.data.GetConditions()
+	for _, cond := range conditions {
+		statusColor := tcell.ColorGreen
+		if !cond.Healthy {
+			statusColor = tcell.ColorRed
+		}
+		p.middleDetailTable.SetCell(row, 0, tview.NewTableCell(fmt.Sprintf("%-18s", cond.Type)).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.middleDetailTable.SetCell(row, 1, tview.NewTableCell(cond.Status).SetTextColor(statusColor).SetSelectable(false))
+		row++
+	}
+
+	// Cordoned status
+	cordonedValue := "[green]False[-]"
+	if node.Unschedulable {
+		cordonedValue = "[red]True[-]"
+	}
+	p.middleDetailTable.SetCell(row, 0, tview.NewTableCell(fmt.Sprintf("%-18s", "Cordoned")).SetTextColor(tcell.ColorGray).SetSelectable(false))
+	p.middleDetailTable.SetCell(row, 1, tview.NewTableCell(cordonedValue).SetSelectable(false))
+	row++
+
+	// Taints
+	taintsValue := "[green]None[-]"
+	if node.TaintCount > 0 {
+		taintsValue = fmt.Sprintf("[yellow]%d[-]", node.TaintCount)
+	}
+	p.middleDetailTable.SetCell(row, 0, tview.NewTableCell(fmt.Sprintf("%-18s", "Taints")).SetTextColor(tcell.ColorGray).SetSelectable(false))
+	p.middleDetailTable.SetCell(row, 1, tview.NewTableCell(taintsValue).SetSelectable(false))
+	row++
+
+	// Pressures
+	pressureValue := "[green]None[-]"
+	if len(node.Pressures) > 0 {
+		pressureValue = "[red]" + strings.Join(node.Pressures, ", ") + "[-]"
+	}
+	p.middleDetailTable.SetCell(row, 0, tview.NewTableCell(fmt.Sprintf("%-18s", "Pressures")).SetTextColor(tcell.ColorGray).SetSelectable(false))
+	p.middleDetailTable.SetCell(row, 1, tview.NewTableCell(pressureValue).SetSelectable(false))
+
+	// === LABELS COLUMN (TextView with sorted keys) ===
+	labels := p.data.GetLabels()
+	var labelsBuilder strings.Builder
+	labelsBuilder.WriteString("[aqua::b]Labels[::-]\n")
+
+	if len(labels) == 0 {
+		labelsBuilder.WriteString("[gray]None[-]")
+	} else {
+		// Sort labels for consistent display
+		labelKeys := make([]string, 0, len(labels))
+		for k := range labels {
+			labelKeys = append(labelKeys, k)
+		}
+		sortStrings(labelKeys)
+
+		for _, k := range labelKeys {
+			v := labels[k]
+			// Truncate long values
+			if len(v) > 25 {
+				v = v[:22] + "..."
+			}
+			labelsBuilder.WriteString(fmt.Sprintf("[gray]%s:[-] %s\n", truncateKey(k), v))
+		}
+	}
+	p.labelsTextView.SetText(labelsBuilder.String())
+
+	// === ANNOTATIONS COLUMN (TextView with sorted keys) ===
+	annotations := p.data.GetAnnotations()
+	var annotationsBuilder strings.Builder
+	annotationsBuilder.WriteString("[aqua::b]Annotations[::-]\n")
+
+	if len(annotations) == 0 {
+		annotationsBuilder.WriteString("[gray]None[-]")
+	} else {
+		// Sort annotations for consistent display
+		annotationKeys := make([]string, 0, len(annotations))
+		for k := range annotations {
+			annotationKeys = append(annotationKeys, k)
+		}
+		sortStrings(annotationKeys)
+
+		for _, k := range annotationKeys {
+			v := annotations[k]
+			// Truncate long values
+			if len(v) > 25 {
+				v = v[:22] + "..."
+			}
+			annotationsBuilder.WriteString(fmt.Sprintf("[gray]%s:[-] %s\n", truncateKey(k), v))
+		}
+	}
+	p.annotationsTextView.SetText(annotationsBuilder.String())
+}
+
+// sortStrings sorts a slice of strings in place
+func sortStrings(s []string) {
+	for i := 0; i < len(s)-1; i++ {
+		for j := i + 1; j < len(s); j++ {
+			if s[i] > s[j] {
+				s[i], s[j] = s[j], s[i]
+			}
+		}
+	}
+}
+
+// truncateKey shortens a label/annotation key for display
+func truncateKey(key string) string {
+	// Remove common prefixes to save space
+	key = strings.TrimPrefix(key, "kubernetes.io/")
+	key = strings.TrimPrefix(key, "node.kubernetes.io/")
+	key = strings.TrimPrefix(key, "topology.kubernetes.io/")
+	if len(key) > 25 {
+		key = key[:22] + "..."
+	}
+	return key
+}
+
+// addDetailRow adds a key-value row to a detail table
+func (p *DetailPanel) addDetailRow(table *tview.Table, row int, key, value string) {
+	// Pad key to minimum width for visual separation
+	paddedKey := fmt.Sprintf("%-10s", key)
+	table.SetCell(row, 0, tview.NewTableCell(paddedKey).SetTextColor(tcell.ColorGray).SetSelectable(false))
+	table.SetCell(row, 1, tview.NewTableCell(value).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+}
+
+// drawEventsTable draws the events table
+func (p *DetailPanel) drawEventsTable() {
+	// Save current selection before clearing
+	selectedRow, selectedCol := p.eventsTable.GetSelection()
+
+	p.eventsTable.Clear()
+
+	// Update title with event count
+	eventCount := 0
+	if p.data != nil {
+		eventCount = len(p.data.Events)
+	}
+	p.eventsPanel.SetTitle(fmt.Sprintf(" Events (%d) ", eventCount))
+
+	// Draw header
+	headers := []string{"TYPE", "REASON", "MESSAGE", "AGE", "COUNT"}
+	for col, header := range headers {
+		expansion := 1
+		if header == "MESSAGE" {
+			expansion = 4 // Give MESSAGE more space
+		}
+		cell := tview.NewTableCell(header).
+			SetTextColor(tcell.ColorYellow).
+			SetBackgroundColor(tcell.ColorDarkGreen).
+			SetSelectable(false).
+			SetExpansion(expansion)
+		p.eventsTable.SetCell(0, col, cell)
+	}
+
+	if p.data == nil || len(p.data.Events) == 0 {
+		// Show "No events" message
+		p.eventsTable.SetCell(1, 0, tview.NewTableCell("").SetSelectable(false))
+		p.eventsTable.SetCell(1, 1, tview.NewTableCell("").SetSelectable(false))
+		p.eventsTable.SetCell(1, 2, tview.NewTableCell("[gray]No events[-]").SetSelectable(false))
+		return
+	}
+
+	// Draw all events (table is scrollable)
+	for i, event := range p.data.Events {
+		rowIdx := i + 1 // Offset for header
+
+		// Type color
+		typeColor := tcell.ColorGreen
+		if event.Type == "Warning" {
+			typeColor = tcell.ColorYellow
+		}
+
+		// Truncate message if too long
+		message := event.Message
+		if len(message) > 80 {
+			message = message[:77] + "..."
+		}
+
+		age := formatEventAge(event)
+		count := fmt.Sprintf("%d", event.Count)
+
+		p.eventsTable.SetCell(rowIdx, 0, tview.NewTableCell(event.Type).SetTextColor(typeColor))
+		p.eventsTable.SetCell(rowIdx, 1, tview.NewTableCell(event.Reason).SetTextColor(tcell.ColorWhite))
+		p.eventsTable.SetCell(rowIdx, 2, tview.NewTableCell(message).SetTextColor(tcell.ColorGray).SetExpansion(4))
+		p.eventsTable.SetCell(rowIdx, 3, tview.NewTableCell(age).SetTextColor(tcell.ColorGray))
+		p.eventsTable.SetCell(rowIdx, 4, tview.NewTableCell(count).SetTextColor(tcell.ColorWhite))
+	}
+
+	// Restore selection (clamped to valid range)
+	maxRow := len(p.data.Events) // +1 for header, but we want max data row index
+	if selectedRow < 1 {
+		selectedRow = 1 // Minimum is first data row
+	} else if selectedRow > maxRow {
+		selectedRow = maxRow
+	}
+	p.eventsTable.Select(selectedRow, selectedCol)
+}
+
+// drawPodsTable draws the scrollable pods table
+func (p *DetailPanel) drawPodsTable() {
+	// Save current selection before clearing
+	selectedRow, selectedCol := p.podsTable.GetSelection()
+
+	p.podsTable.Clear()
+
+	// Update title with pod count
+	if p.data != nil {
+		p.podsPanel.SetTitle(fmt.Sprintf(" Pods (%d) ", len(p.data.PodsOnNode)))
+	}
+
+	// Draw header
+	headers := []string{"NAMESPACE", "NAME", "STATUS", "READY", "RESTARTS", "CPU", "MEM", "AGE"}
+	for col, header := range headers {
+		cell := tview.NewTableCell(header).
+			SetTextColor(tcell.ColorYellow).
+			SetBackgroundColor(tcell.ColorDarkGreen).
+			SetSelectable(false).
+			SetExpansion(1)
+		p.podsTable.SetCell(0, col, cell)
+	}
+
+	if p.data == nil || len(p.data.PodsOnNode) == 0 {
+		return
+	}
+
+	// Draw pods
+	for row, pod := range p.data.PodsOnNode {
+		rowIdx := row + 1 // Offset for header
+
+		statusColor := ui.GetTcellColor(ui.GetStatusColor(pod.Status, "pod"))
+		readyStr := fmt.Sprintf("%d/%d", pod.ReadyContainers, pod.TotalContainers)
+
+		restartColor := tcell.ColorGreen
+		if pod.Restarts > 0 {
+			restartColor = tcell.ColorYellow
+		}
+		if pod.Restarts > 5 {
+			restartColor = tcell.ColorRed
+		}
+
+		// CPU and Memory
+		cpuStr := "n/a"
+		memStr := "n/a"
+		if pod.PodUsageCpuQty != nil {
+			cpuStr = fmt.Sprintf("%dm", pod.PodUsageCpuQty.MilliValue())
+		}
+		if pod.PodUsageMemQty != nil {
+			memStr = ui.FormatMemory(pod.PodUsageMemQty)
+		}
+
+		p.podsTable.SetCell(rowIdx, 0, tview.NewTableCell(pod.Namespace).SetTextColor(tcell.ColorWhite))
+		p.podsTable.SetCell(rowIdx, 1, tview.NewTableCell(pod.Name).SetTextColor(tcell.ColorWhite).SetMaxWidth(30))
+		p.podsTable.SetCell(rowIdx, 2, tview.NewTableCell(pod.Status).SetTextColor(statusColor))
+		p.podsTable.SetCell(rowIdx, 3, tview.NewTableCell(readyStr).SetTextColor(tcell.ColorWhite))
+		p.podsTable.SetCell(rowIdx, 4, tview.NewTableCell(fmt.Sprintf("%d", pod.Restarts)).SetTextColor(restartColor))
+		p.podsTable.SetCell(rowIdx, 5, tview.NewTableCell(cpuStr).SetTextColor(tcell.ColorWhite))
+		p.podsTable.SetCell(rowIdx, 6, tview.NewTableCell(memStr).SetTextColor(tcell.ColorWhite))
+		p.podsTable.SetCell(rowIdx, 7, tview.NewTableCell(pod.TimeSince).SetTextColor(tcell.ColorGray))
+	}
+
+	// Restore selection (clamped to valid range)
+	maxRow := len(p.data.PodsOnNode) // +1 for header, but we want max data row index
+	if selectedRow < 1 {
+		selectedRow = 1 // Minimum is first data row
+	} else if selectedRow > maxRow {
+		selectedRow = maxRow
+	}
+	p.podsTable.Select(selectedRow, selectedCol)
+}
+
+// Helper functions
+
+func formatCPU(q *resource.Quantity) string {
+	if q == nil {
+		return "n/a"
+	}
+	return fmt.Sprintf("%dm", q.MilliValue())
+}
+
+func formatMemory(q *resource.Quantity) string {
+	if q == nil {
+		return "n/a"
+	}
+	return ui.FormatMemory(q)
+}
+
+func formatStorage(q *resource.Quantity) string {
+	if q == nil {
+		return "n/a"
+	}
+	return fmt.Sprintf("%dGi", q.ScaledValue(resource.Giga))
+}
+
+func formatEventAge(event corev1.Event) string {
+	var eventTime time.Time
+	if !event.LastTimestamp.IsZero() {
+		eventTime = event.LastTimestamp.Time
+	} else if !event.EventTime.IsZero() {
+		eventTime = event.EventTime.Time
+	} else if !event.FirstTimestamp.IsZero() {
+		eventTime = event.FirstTimestamp.Time
+	} else {
+		return "?"
+	}
+
+	duration := time.Since(eventTime)
+	if duration < time.Minute {
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	} else if duration < time.Hour {
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	} else if duration < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(duration.Hours()/24))
+}
+
+// DrawFooter draws the footer
+func (p *DetailPanel) DrawFooter(_ interface{}) {}
+
+// Clear clears the panel
+func (p *DetailPanel) Clear() {
+	if p.podsTable != nil {
+		p.podsTable.Clear()
+	}
+}
+
+// GetRootView returns the root view
+func (p *DetailPanel) GetRootView() tview.Primitive {
+	return p.root
+}
+
+// GetChildrenViews returns child views
+func (p *DetailPanel) GetChildrenViews() []tview.Primitive {
+	return nil
+}
+
+// SetAppFocus sets the callback used to focus primitives in the tview app
+func (p *DetailPanel) SetAppFocus(fn func(p tview.Primitive)) {
+	p.setAppFocus = fn
+}
+
+// InitFocus sets up initial focus when the page is shown
+func (p *DetailPanel) InitFocus() {
+	p.focusedChildIdx = 0 // Start with events
+	p.updateFocusVisuals()
+}
+
+// cycleFocus moves focus to the next focusable child
+func (p *DetailPanel) cycleFocus() {
+	if len(p.focusableItems) == 0 {
+		return
+	}
+	p.focusedChildIdx = (p.focusedChildIdx + 1) % len(p.focusableItems)
+	p.updateFocusVisuals()
+}
+
+// cycleFocusReverse moves focus to the previous focusable child
+func (p *DetailPanel) cycleFocusReverse() {
+	if len(p.focusableItems) == 0 {
+		return
+	}
+	p.focusedChildIdx--
+	if p.focusedChildIdx < 0 {
+		p.focusedChildIdx = len(p.focusableItems) - 1
+	}
+	p.updateFocusVisuals()
+}
+
+// updateFocusVisuals updates border colors and sets tview focus
+func (p *DetailPanel) updateFocusVisuals() {
+	// Update border colors for all focusable panels
+	for i, panel := range p.focusablePanels {
+		if i == p.focusedChildIdx {
+			panel.SetBorderColor(tcell.ColorYellow)
+		} else {
+			panel.SetBorderColor(tcell.ColorWhite)
+		}
+	}
+
+	// Set tview focus to the currently focused item
+	if p.setAppFocus != nil && p.focusedChildIdx >= 0 && p.focusedChildIdx < len(p.focusableItems) {
+		p.setAppFocus(p.focusableItems[p.focusedChildIdx])
+	}
+}
+
+// SetFocused implements ui.FocusablePanel
+func (p *DetailPanel) SetFocused(focused bool) {
+	ui.SetFlexFocused(p.root, focused)
+	if focused {
+		// When the panel receives focus, update visuals for the currently focused child
+		p.updateFocusVisuals()
+	}
+}
+
+// HasEscapableState implements ui.EscapablePanel
+func (p *DetailPanel) HasEscapableState() bool {
+	return true // Always allow ESC to go back
+}
+
+// HandleEscape implements ui.EscapablePanel
+func (p *DetailPanel) HandleEscape() bool {
+	if p.onBack != nil {
+		p.onBack()
+		return true
+	}
+	return false
+}

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -11,6 +11,8 @@ import (
 	"github.com/vladimirvivien/ktop/metrics"
 	"github.com/vladimirvivien/ktop/ui"
 	"github.com/vladimirvivien/ktop/views/model"
+	nodedetail "github.com/vladimirvivien/ktop/views/node"
+	poddetail "github.com/vladimirvivien/ktop/views/pod"
 	v1 "k8s.io/api/core/v1"
 	// metrics package imported for SourceTypePrometheus constant
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,6 +37,15 @@ type MainPanel struct {
 	podColumns          []string
 	namespaceFilter     string            // Current namespace filter
 	cachedPodModels     []model.PodModel  // Cached pod models for immediate re-filtering
+	cachedNodeModels    []model.NodeModel // Cached node models for detail view
+
+	// Detail panels
+	nodeDetailPanel *nodedetail.DetailPanel
+	podDetailPanel  *poddetail.DetailPanel
+
+	// Track currently displayed detail view for live updates
+	currentDetailNodeName string // Non-empty when node detail is displayed
+	currentDetailPodKey   string // "namespace/name" when pod detail is displayed
 }
 
 func New(app *application.Application, title string) *MainPanel {
@@ -80,12 +91,26 @@ func (p *MainPanel) Layout(data interface{}) {
 	p.nodePanel = NewNodePanel(p.app, fmt.Sprintf(" %s Nodes ", ui.Icons.Factory))
 	p.nodePanel.DrawHeader(nodeColumnsToDisplay)
 
+	// Set up node selection callback for navigation
+	if np, ok := p.nodePanel.(*nodePanel); ok {
+		np.SetOnNodeSelected(func(nodeName string) {
+			p.app.NavigateToNodeDetail(nodeName)
+		})
+	}
+
 	p.clusterSummaryPanel = NewClusterSummaryPanel(p.app, fmt.Sprintf(" %s Cluster Summary ", ui.Icons.Thermometer))
 	p.clusterSummaryPanel.Layout(nil)
 	p.clusterSummaryPanel.DrawHeader(nil)
 
 	p.podPanel = NewPodPanel(p.app, fmt.Sprintf(" %s Pods ", ui.Icons.Package))
 	p.podPanel.DrawHeader(podColumnsToDisplay)
+
+	// Set up pod selection callback for navigation
+	if pp, ok := p.podPanel.(*podPanel); ok {
+		pp.SetOnPodSelected(func(namespace, podName string) {
+			p.app.NavigateToPodDetail(namespace, podName)
+		})
+	}
 
 	p.children = []tview.Primitive{
 		p.clusterSummaryPanel.GetRootView(),
@@ -189,10 +214,233 @@ func (p *MainPanel) Run(ctx context.Context) error {
 		p.displayFilteredPods()
 	})
 
+	// Set up navigation callbacks on the app (detail panels created lazily on first use)
+	p.app.SetNodeDetailCallback(p.showNodeDetail)
+	p.app.SetPodDetailCallback(p.showPodDetail)
+
 	if err := ctrl.Start(ctx, time.Second*10); err != nil {
 		panic(fmt.Sprintf("main panel: controller start: %s", err))
 	}
 	return nil
+}
+
+// ensureNodeDetailPanel creates the node detail panel if not already created
+func (p *MainPanel) ensureNodeDetailPanel() {
+	if p.nodeDetailPanel != nil {
+		return
+	}
+	p.nodeDetailPanel = nodedetail.NewDetailPanel()
+	p.nodeDetailPanel.SetOnBack(func() {
+		p.currentDetailNodeName = "" // Clear tracking on back navigation
+		p.app.NavigateBack()
+	})
+	p.nodeDetailPanel.SetOnPodSelected(func(namespace, podName string) {
+		p.app.NavigateToPodDetail(namespace, podName)
+	})
+	// Set up focus callback for tab cycling within the detail panel
+	p.nodeDetailPanel.SetAppFocus(func(prim tview.Primitive) {
+		p.app.Focus(prim)
+	})
+	p.app.AddDetailPage("node_detail", p.nodeDetailPanel.GetRootView())
+}
+
+// ensurePodDetailPanel creates the pod detail panel if not already created
+func (p *MainPanel) ensurePodDetailPanel() {
+	if p.podDetailPanel != nil {
+		return
+	}
+	p.podDetailPanel = poddetail.NewDetailPanel()
+	p.podDetailPanel.SetOnBack(func() {
+		p.currentDetailPodKey = "" // Clear tracking on back navigation
+		p.app.NavigateBack()
+	})
+	p.podDetailPanel.SetOnNodeNavigate(func(nodeName string) {
+		p.app.NavigateToNodeDetail(nodeName)
+	})
+	p.app.AddDetailPage("pod_detail", p.podDetailPanel.GetRootView())
+}
+
+// showNodeDetail navigates to the node detail view
+func (p *MainPanel) showNodeDetail(nodeName string) {
+	// Ensure the detail panel exists (lazy initialization)
+	p.ensureNodeDetailPanel()
+
+	// Find the node model in cached data
+	var nodeModel *model.NodeModel
+	for i := range p.cachedNodeModels {
+		if p.cachedNodeModels[i].Name == nodeName {
+			// Copy the model to avoid pointer to slice element issues
+			nm := p.cachedNodeModels[i]
+			nodeModel = &nm
+			break
+		}
+	}
+
+	if nodeModel == nil {
+		return // Node not found
+	}
+
+	// Find pods on this node
+	var podsOnNode []*model.PodModel
+	for i := range p.cachedPodModels {
+		if p.cachedPodModels[i].Node == nodeName {
+			pm := p.cachedPodModels[i]
+			podsOnNode = append(podsOnNode, &pm)
+		}
+	}
+
+	// Create detail data
+	detailData := &model.NodeDetailData{
+		NodeModel:  nodeModel,
+		PodsOnNode: podsOnNode,
+	}
+
+	ctx := context.Background()
+
+	// Fetch metrics history for sparklines (if available)
+	if p.metricsSource != nil && p.metricsSource.SupportsHistory() {
+		historyDuration := 5 * time.Minute
+		sparklineWidth := 15 // Number of data points for sparkline
+
+		// Fetch CPU history
+		cpuHistory, err := p.metricsSource.GetNodeHistory(ctx, nodeName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceCPU,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		// Fetch Memory history
+		memHistory, err2 := p.metricsSource.GetNodeHistory(ctx, nodeName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceMemory,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		// Convert to MetricSample format for the detail view
+		if err == nil && cpuHistory != nil && err2 == nil && memHistory != nil {
+			// Get allocatable values for calculating ratios
+			allocCPU := int64(1) // Default to avoid division by zero
+			allocMem := int64(1)
+			if nodeModel.AllocatableCpuQty != nil {
+				allocCPU = nodeModel.AllocatableCpuQty.MilliValue()
+			}
+			if nodeModel.AllocatableMemQty != nil {
+				allocMem = nodeModel.AllocatableMemQty.Value()
+			}
+
+			// Merge CPU and memory history into MetricSamples
+			detailData.MetricsHistory = mergeHistoryToSamples(cpuHistory, memHistory, allocCPU, allocMem)
+		}
+	}
+
+	// Fetch the raw Node object for conditions, labels, etc.
+	ctrl := p.app.GetK8sClient().Controller()
+	if node, err := ctrl.GetNode(ctx, nodeName); err == nil {
+		detailData.Node = node
+	}
+
+	// Fetch events for this node
+	if events, err := ctrl.GetEventsForNode(ctx, nodeName); err == nil {
+		detailData.Events = events
+	}
+
+	// Track that we're showing node detail for live updates
+	p.currentDetailNodeName = nodeName
+	p.currentDetailPodKey = "" // Clear pod tracking
+
+	// Update and show the detail panel
+	p.nodeDetailPanel.DrawBody(detailData)
+	p.app.ShowDetailPage("node_detail")
+	p.nodeDetailPanel.InitFocus() // Set up initial focus on events panel
+}
+
+// showPodDetail navigates to the pod detail view
+func (p *MainPanel) showPodDetail(namespace, podName string) {
+	// Ensure the detail panel exists (lazy initialization)
+	p.ensurePodDetailPanel()
+
+	// Find the pod model in cached data
+	var podModel *model.PodModel
+	for i := range p.cachedPodModels {
+		if p.cachedPodModels[i].Namespace == namespace && p.cachedPodModels[i].Name == podName {
+			podModel = &p.cachedPodModels[i]
+			break
+		}
+	}
+
+	if podModel == nil {
+		return // Pod not found
+	}
+
+	// Create detail data
+	detailData := &model.PodDetailData{
+		PodModel: podModel,
+	}
+
+	ctx := context.Background()
+
+	// Fetch metrics history for sparklines (if available)
+	if p.metricsSource != nil && p.metricsSource.SupportsHistory() {
+		historyDuration := 5 * time.Minute
+		sparklineWidth := 15 // Number of data points for sparkline
+
+		// Fetch CPU history
+		cpuHistory, err := p.metricsSource.GetPodHistory(ctx, namespace, podName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceCPU,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		// Fetch Memory history
+		memHistory, err2 := p.metricsSource.GetPodHistory(ctx, namespace, podName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceMemory,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		// Convert to MetricSample format for the detail view
+		if err == nil && cpuHistory != nil && err2 == nil && memHistory != nil {
+			// For pods, we use requested resources as the baseline for ratios
+			// Default values if no requests are set
+			allocCPU := int64(1000)    // 1 core default
+			allocMem := int64(1 << 30) // 1 GB default
+			if podModel.PodRequestedCpuQty != nil && podModel.PodRequestedCpuQty.MilliValue() > 0 {
+				allocCPU = podModel.PodRequestedCpuQty.MilliValue()
+			} else if podModel.NodeAllocatableCpuQty != nil && podModel.NodeAllocatableCpuQty.MilliValue() > 0 {
+				// Fallback to node allocatable for pods without requests
+				allocCPU = podModel.NodeAllocatableCpuQty.MilliValue()
+			}
+			if podModel.PodRequestedMemQty != nil && podModel.PodRequestedMemQty.Value() > 0 {
+				allocMem = podModel.PodRequestedMemQty.Value()
+			} else if podModel.NodeAllocatableMemQty != nil && podModel.NodeAllocatableMemQty.Value() > 0 {
+				// Fallback to node allocatable for pods without requests
+				allocMem = podModel.NodeAllocatableMemQty.Value()
+			}
+
+			// Store as pod-level aggregate (single entry in map)
+			samples := mergeHistoryToSamples(cpuHistory, memHistory, allocCPU, allocMem)
+			if len(samples) > 0 {
+				detailData.MetricsHistory = map[string][]model.MetricSample{
+					"pod": samples,
+				}
+			}
+		}
+	}
+
+	// Fetch events for this pod
+	ctrl := p.app.GetK8sClient().Controller()
+	if events, err := ctrl.GetEventsForPod(ctx, namespace, podName); err == nil {
+		detailData.Events = events
+	}
+
+	// Track that we're showing pod detail for live updates
+	p.currentDetailPodKey = namespace + "/" + podName
+	p.currentDetailNodeName = "" // Clear node tracking
+
+	// Update and show the detail panel
+	p.podDetailPanel.DrawBody(detailData)
+	p.app.ShowDetailPage("pod_detail")
+	p.app.Focus(p.podDetailPanel.GetRootView())
 }
 
 func (p *MainPanel) refreshNodeView(ctx context.Context, models []model.NodeModel) error {
@@ -222,11 +470,24 @@ func (p *MainPanel) refreshNodeView(ctx context.Context, models []model.NodeMode
 		nodeModels = append(nodeModels, existingModel)
 	}
 
+	// Pre-fetch node detail data if detail view is visible (do network calls outside QueueUpdateDraw)
+	var nodeDetailData *model.NodeDetailData
+	if p.currentDetailNodeName != "" && p.nodeDetailPanel != nil {
+		nodeDetailData = p.buildNodeDetailData(ctx, p.currentDetailNodeName, nodeModels)
+	}
+
 	// Queue UI update on main goroutine to avoid race with Draw()
 	// This is called from controller goroutine, so we must synchronize
 	p.app.QueueUpdateDraw(func() {
+		// Cache the updated models for detail view access
+		p.cachedNodeModels = nodeModels
 		p.nodePanel.Clear()
 		p.nodePanel.DrawBody(nodeModels)
+
+		// If node detail is currently displayed, update it with pre-fetched data
+		if nodeDetailData != nil && p.nodeDetailPanel != nil {
+			p.nodeDetailPanel.DrawBody(nodeDetailData)
+		}
 	})
 
 	return nil
@@ -277,6 +538,12 @@ func (p *MainPanel) refreshPods(ctx context.Context, models []model.PodModel) er
 		}
 	}
 
+	// Pre-fetch pod detail data if detail view is visible (do network calls outside QueueUpdateDraw)
+	var podDetailData *model.PodDetailData
+	if p.currentDetailPodKey != "" && p.podDetailPanel != nil {
+		podDetailData = p.buildPodDetailData(ctx, p.currentDetailPodKey, updatedModels)
+	}
+
 	// Queue UI update on main goroutine to avoid race with Draw()
 	// This is called from controller goroutine, so we must synchronize
 	p.app.QueueUpdateDraw(func() {
@@ -284,6 +551,11 @@ func (p *MainPanel) refreshPods(ctx context.Context, models []model.PodModel) er
 		p.cachedPodModels = updatedModels
 		// Apply namespace filter and display
 		p.displayFilteredPodsInternal()
+
+		// If pod detail is currently displayed, update it with pre-fetched data
+		if podDetailData != nil && p.podDetailPanel != nil {
+			p.podDetailPanel.DrawBody(podDetailData)
+		}
 	})
 
 	return nil
@@ -327,6 +599,169 @@ func (p *MainPanel) displayFilteredPodsInternal() {
 	// Sorting is now handled by the panel itself in DrawBody
 	p.podPanel.Clear()
 	p.podPanel.DrawBody(filteredModels)
+}
+
+// buildNodeDetailData builds the node detail data for live updates.
+// This performs network calls and must be called outside QueueUpdateDraw.
+func (p *MainPanel) buildNodeDetailData(ctx context.Context, nodeName string, nodeModels []model.NodeModel) *model.NodeDetailData {
+	if nodeName == "" {
+		return nil
+	}
+
+	// Find the node model in the provided models
+	var nodeModel *model.NodeModel
+	for i := range nodeModels {
+		if nodeModels[i].Name == nodeName {
+			// Copy the model to avoid pointer to slice element issues
+			nm := nodeModels[i]
+			nodeModel = &nm
+			break
+		}
+	}
+
+	if nodeModel == nil {
+		return nil // Node no longer exists
+	}
+
+	// Find pods on this node from cached pods
+	var podsOnNode []*model.PodModel
+	for i := range p.cachedPodModels {
+		if p.cachedPodModels[i].Node == nodeName {
+			pm := p.cachedPodModels[i]
+			podsOnNode = append(podsOnNode, &pm)
+		}
+	}
+
+	// Create detail data
+	detailData := &model.NodeDetailData{
+		NodeModel:  nodeModel,
+		PodsOnNode: podsOnNode,
+	}
+
+	// Fetch metrics history for sparklines (if available)
+	if p.metricsSource != nil && p.metricsSource.SupportsHistory() {
+		historyDuration := 5 * time.Minute
+		sparklineWidth := 15
+
+		cpuHistory, err := p.metricsSource.GetNodeHistory(ctx, nodeName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceCPU,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		memHistory, err2 := p.metricsSource.GetNodeHistory(ctx, nodeName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceMemory,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		if err == nil && cpuHistory != nil && err2 == nil && memHistory != nil {
+			allocCPU := int64(1)
+			allocMem := int64(1)
+			if nodeModel.AllocatableCpuQty != nil {
+				allocCPU = nodeModel.AllocatableCpuQty.MilliValue()
+			}
+			if nodeModel.AllocatableMemQty != nil {
+				allocMem = nodeModel.AllocatableMemQty.Value()
+			}
+
+			detailData.MetricsHistory = mergeHistoryToSamples(cpuHistory, memHistory, allocCPU, allocMem)
+		}
+	}
+
+	// Fetch the raw Node object for conditions, labels, etc.
+	ctrl := p.app.GetK8sClient().Controller()
+	if node, err := ctrl.GetNode(ctx, nodeName); err == nil {
+		detailData.Node = node
+	}
+
+	// Fetch events for this node
+	if events, err := ctrl.GetEventsForNode(ctx, nodeName); err == nil {
+		detailData.Events = events
+	}
+
+	return detailData
+}
+
+// buildPodDetailData builds the pod detail data for live updates.
+// This performs network calls and must be called outside QueueUpdateDraw.
+func (p *MainPanel) buildPodDetailData(ctx context.Context, podKey string, podModels []model.PodModel) *model.PodDetailData {
+	if podKey == "" {
+		return nil
+	}
+
+	// Parse namespace/name from key
+	parts := strings.SplitN(podKey, "/", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	namespace, podName := parts[0], parts[1]
+
+	// Find the pod model in provided models
+	var podModel *model.PodModel
+	for i := range podModels {
+		if podModels[i].Namespace == namespace && podModels[i].Name == podName {
+			podModel = &podModels[i]
+			break
+		}
+	}
+
+	if podModel == nil {
+		return nil // Pod no longer exists
+	}
+
+	// Create detail data
+	detailData := &model.PodDetailData{
+		PodModel: podModel,
+	}
+
+	// Fetch metrics history for sparklines (if available)
+	if p.metricsSource != nil && p.metricsSource.SupportsHistory() {
+		historyDuration := 5 * time.Minute
+		sparklineWidth := 15
+
+		cpuHistory, err := p.metricsSource.GetPodHistory(ctx, namespace, podName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceCPU,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		memHistory, err2 := p.metricsSource.GetPodHistory(ctx, namespace, podName, metrics.HistoryQuery{
+			Resource:  metrics.ResourceMemory,
+			Duration:  historyDuration,
+			MaxPoints: sparklineWidth,
+		})
+
+		if err == nil && cpuHistory != nil && err2 == nil && memHistory != nil {
+			allocCPU := int64(1000)
+			allocMem := int64(1 << 30)
+			if podModel.PodRequestedCpuQty != nil && podModel.PodRequestedCpuQty.MilliValue() > 0 {
+				allocCPU = podModel.PodRequestedCpuQty.MilliValue()
+			} else if podModel.NodeAllocatableCpuQty != nil && podModel.NodeAllocatableCpuQty.MilliValue() > 0 {
+				allocCPU = podModel.NodeAllocatableCpuQty.MilliValue()
+			}
+			if podModel.PodRequestedMemQty != nil && podModel.PodRequestedMemQty.Value() > 0 {
+				allocMem = podModel.PodRequestedMemQty.Value()
+			} else if podModel.NodeAllocatableMemQty != nil && podModel.NodeAllocatableMemQty.Value() > 0 {
+				allocMem = podModel.NodeAllocatableMemQty.Value()
+			}
+
+			samples := mergeHistoryToSamples(cpuHistory, memHistory, allocCPU, allocMem)
+			if len(samples) > 0 {
+				detailData.MetricsHistory = map[string][]model.MetricSample{
+					"pod": samples,
+				}
+			}
+		}
+	}
+
+	// Fetch events for this pod
+	ctrl := p.app.GetK8sClient().Controller()
+	if events, err := ctrl.GetEventsForPod(ctx, namespace, podName); err == nil {
+		detailData.Events = events
+	}
+
+	return detailData
 }
 
 // podMetricsTotals sums up CPU and memory usage across all containers in a pod
@@ -441,4 +876,63 @@ func convertToV1Beta1PodMetrics(pm *metrics.PodMetrics) *metricsV1beta1.PodMetri
 		Window:     metav1.Duration{Duration: 0},
 		Containers: containers,
 	}
+}
+
+// mergeHistoryToSamples converts ResourceHistory data points to MetricSamples for sparklines.
+// CPU values are in millicores, memory values are in bytes.
+// allocCPU is in millicores, allocMem is in bytes.
+func mergeHistoryToSamples(cpuHistory, memHistory *metrics.ResourceHistory, allocCPU, allocMem int64) []model.MetricSample {
+	// Use the shorter of the two histories
+	cpuLen := 0
+	memLen := 0
+	if cpuHistory != nil {
+		cpuLen = len(cpuHistory.DataPoints)
+	}
+	if memHistory != nil {
+		memLen = len(memHistory.DataPoints)
+	}
+
+	// Determine result size
+	resultLen := cpuLen
+	if memLen < resultLen {
+		resultLen = memLen
+	}
+	if resultLen == 0 {
+		return nil
+	}
+
+	samples := make([]model.MetricSample, resultLen)
+	for i := 0; i < resultLen; i++ {
+		sample := model.MetricSample{}
+
+		// CPU ratio: value is in millicores, divide by allocatable millicores
+		if cpuHistory != nil && i < len(cpuHistory.DataPoints) {
+			dp := cpuHistory.DataPoints[i]
+			sample.Timestamp = dp.Timestamp.UnixMilli()
+			if allocCPU > 0 {
+				sample.CPURatio = dp.Value / float64(allocCPU)
+				if sample.CPURatio > 1.0 {
+					sample.CPURatio = 1.0
+				}
+			}
+		}
+
+		// Memory ratio: value is in bytes, divide by allocatable bytes
+		if memHistory != nil && i < len(memHistory.DataPoints) {
+			dp := memHistory.DataPoints[i]
+			if sample.Timestamp == 0 {
+				sample.Timestamp = dp.Timestamp.UnixMilli()
+			}
+			if allocMem > 0 {
+				sample.MemRatio = dp.Value / float64(allocMem)
+				if sample.MemRatio > 1.0 {
+					sample.MemRatio = 1.0
+				}
+			}
+		}
+
+		samples[i] = sample
+	}
+
+	return samples
 }

--- a/views/pod/detail.go
+++ b/views/pod/detail.go
@@ -1,0 +1,632 @@
+package pod
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/vladimirvivien/ktop/metrics"
+	"github.com/vladimirvivien/ktop/ui"
+	"github.com/vladimirvivien/ktop/views/model"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeNavigationCallback is called when user wants to navigate to the pod's node
+type NodeNavigationCallback func(nodeName string)
+
+// DetailPanel displays detailed information about a pod
+type DetailPanel struct {
+	root     *tview.Flex
+	table    *tview.Table
+	data     *model.PodDetailData
+	laidout  bool
+	rowIndex int // Current row being written to
+
+	// Callbacks
+	onNodeNavigate NodeNavigationCallback
+	onBack         func()
+}
+
+// NewDetailPanel creates a new pod detail panel
+func NewDetailPanel() *DetailPanel {
+	p := &DetailPanel{}
+	p.Layout(nil)
+	return p
+}
+
+// SetOnNodeNavigate sets the callback for navigating to the pod's node
+func (p *DetailPanel) SetOnNodeNavigate(callback NodeNavigationCallback) {
+	p.onNodeNavigate = callback
+}
+
+// SetOnBack sets the callback for when user navigates back
+func (p *DetailPanel) SetOnBack(callback func()) {
+	p.onBack = callback
+}
+
+// GetTitle returns the panel title
+func (p *DetailPanel) GetTitle() string {
+	if p.data != nil && p.data.PodModel != nil {
+		return fmt.Sprintf("Pod: %s/%s", p.data.PodModel.Namespace, p.data.PodModel.Name)
+	}
+	return "Pod Detail"
+}
+
+// Layout initializes the panel UI
+func (p *DetailPanel) Layout(_ interface{}) {
+	if !p.laidout {
+		p.table = tview.NewTable()
+		p.table.SetBorder(false)
+		p.table.SetBorders(false)
+		p.table.SetSelectable(false, false)
+
+		// Set up keyboard handling
+		p.table.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyEscape:
+				if p.onBack != nil {
+					p.onBack()
+					return nil
+				}
+			case tcell.KeyRune:
+				// 'n' to navigate to node detail
+				if event.Rune() == 'n' || event.Rune() == 'N' {
+					if p.data != nil && p.data.PodModel != nil && p.onNodeNavigate != nil {
+						p.onNodeNavigate(p.data.PodModel.Node)
+						return nil
+					}
+				}
+			}
+			return event
+		})
+
+		p.root = tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(p.table, 0, 1, true)
+		p.root.SetBorder(true)
+		p.root.SetTitle(" Pod Detail ")
+		p.root.SetTitleAlign(tview.AlignLeft)
+		p.laidout = true
+	}
+}
+
+// DrawHeader draws the header row
+func (p *DetailPanel) DrawHeader(data interface{}) {
+	// Header is part of the table content
+}
+
+// DrawBody draws the main content
+func (p *DetailPanel) DrawBody(data interface{}) {
+	detailData, ok := data.(*model.PodDetailData)
+	if !ok {
+		return
+	}
+	p.data = detailData
+	p.table.Clear()
+	p.rowIndex = 0
+
+	// Update title with pod name and status
+	if p.data.PodModel != nil {
+		status := p.data.PodModel.Status
+		statusColor := ui.GetStatusColor(status, "pod")
+		p.root.SetTitle(fmt.Sprintf(" [::b]Pod:[::] %s/%s [%s](%s)[-] ", p.data.PodModel.Namespace, p.data.PodModel.Name, statusColor, status))
+	}
+
+	// Draw sections
+	p.drawInfoSection()
+	p.drawContainersSection()
+	p.drawResourcesSection()
+	p.drawVolumesSection()
+	p.drawConditionsSection()
+	p.drawEventsSection()
+	p.drawLabelsSection()
+}
+
+// drawInfoSection draws the basic pod information
+func (p *DetailPanel) drawInfoSection() {
+	if p.data == nil || p.data.PodModel == nil {
+		return
+	}
+	pod := p.data.PodModel
+
+	p.addSectionHeader("Information")
+
+	// Basic info
+	p.addKeyValue("Name", pod.Name)
+	p.addKeyValue("Namespace", pod.Namespace)
+	p.addKeyValue("Status", pod.Status)
+	p.addKeyValue("Age", pod.TimeSince)
+	p.addKeyValue("Pod IP", pod.IP)
+	p.addKeyValue("Node", fmt.Sprintf("%s [yellow](press 'n' to view)[-]", pod.Node))
+
+	// Additional info from full Pod object
+	if p.data.Pod != nil {
+		p.addEmptyRow()
+		p.addKeyValue("QoS Class", string(p.data.Pod.Status.QOSClass))
+		p.addKeyValue("Service Account", p.data.Pod.Spec.ServiceAccountName)
+
+		// Priority
+		if p.data.Pod.Spec.Priority != nil {
+			p.addKeyValue("Priority", fmt.Sprintf("%d", *p.data.Pod.Spec.Priority))
+		}
+
+		// Restart policy
+		p.addKeyValue("Restart Policy", string(p.data.Pod.Spec.RestartPolicy))
+
+		// Owner references
+		owners := p.data.GetOwnerReferences()
+		if len(owners) > 0 {
+			for i, owner := range owners {
+				key := "Owner"
+				if i > 0 {
+					key = ""
+				}
+				controllerStr := ""
+				if owner.Controller {
+					controllerStr = " [green](controller)[-]"
+				}
+				p.addKeyValue(key, fmt.Sprintf("%s/%s%s", owner.Kind, owner.Name, controllerStr))
+			}
+		}
+	}
+}
+
+// drawContainersSection draws the containers information
+func (p *DetailPanel) drawContainersSection() {
+	containers := p.data.GetContainers()
+	if len(containers) == 0 {
+		return
+	}
+
+	p.addSectionHeader(fmt.Sprintf("Containers (%d)", len(containers)))
+
+	// Header row
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  NAME").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("STATE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell("READY").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 3, tview.NewTableCell("RESTARTS").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 4, tview.NewTableCell("IMAGE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.rowIndex++
+
+	for _, container := range containers {
+		stateColor := tcell.ColorGreen
+		if container.State != "Running" {
+			stateColor = tcell.ColorYellow
+		}
+		if container.State == "Terminated" || container.State == "CrashLoopBackOff" || container.State == "Error" {
+			stateColor = tcell.ColorRed
+		}
+
+		readyStr := "No"
+		readyColor := tcell.ColorRed
+		if container.Ready {
+			readyStr = "Yes"
+			readyColor = tcell.ColorGreen
+		}
+
+		restartColor := tcell.ColorGreen
+		if container.RestartCount > 0 {
+			restartColor = tcell.ColorYellow
+		}
+		if container.RestartCount > 5 {
+			restartColor = tcell.ColorRed
+		}
+
+		// Truncate image if too long
+		image := container.Image
+		if len(image) > 50 {
+			image = image[:47] + "..."
+		}
+
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+container.Name).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(container.State).SetTextColor(stateColor).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(readyStr).SetTextColor(readyColor).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 3, tview.NewTableCell(fmt.Sprintf("%d", container.RestartCount)).SetTextColor(restartColor).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 4, tview.NewTableCell(image).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.rowIndex++
+
+		// Show probes on separate lines if configured
+		if container.LivenessProbe != "" {
+			p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("").SetSelectable(false))
+			p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("  Liveness:").SetTextColor(tcell.ColorGray).SetSelectable(false))
+			p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(container.LivenessProbe).SetTextColor(tcell.ColorWhite).SetSelectable(false).SetExpansion(3))
+			p.rowIndex++
+		}
+		if container.ReadinessProbe != "" {
+			p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("").SetSelectable(false))
+			p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("  Readiness:").SetTextColor(tcell.ColorGray).SetSelectable(false))
+			p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(container.ReadinessProbe).SetTextColor(tcell.ColorWhite).SetSelectable(false).SetExpansion(3))
+			p.rowIndex++
+		}
+	}
+}
+
+// drawResourcesSection draws the resource requests/limits section
+func (p *DetailPanel) drawResourcesSection() {
+	containers := p.data.GetContainers()
+	if len(containers) == 0 {
+		return
+	}
+
+	p.addSectionHeader("Resources")
+
+	// Show pod-level usage with sparklines if available
+	pod := p.data.PodModel
+	if pod != nil {
+		// Build CPU and memory history from MetricsHistory
+		var cpuHistory, memHistory *metrics.ResourceHistory
+		if p.data.MetricsHistory != nil {
+			// Use "pod" key for aggregate metrics
+			if samples, ok := p.data.MetricsHistory["pod"]; ok && len(samples) > 0 {
+				cpuHistory = p.buildCPUHistory(samples)
+				memHistory = p.buildMemHistory(samples)
+			}
+		}
+
+		// CPU usage
+		cpuUsage := ""
+		cpuCapacity := ""
+		cpuPercent := 0.0
+		if pod.PodUsageCpuQty != nil {
+			cpuUsage = fmt.Sprintf("%dm", pod.PodUsageCpuQty.MilliValue())
+		}
+		if pod.NodeAllocatableCpuQty != nil && pod.NodeAllocatableCpuQty.MilliValue() > 0 {
+			cpuCapacity = fmt.Sprintf("%dm", pod.NodeAllocatableCpuQty.MilliValue())
+			if pod.PodUsageCpuQty != nil {
+				cpuPercent = float64(pod.PodUsageCpuQty.MilliValue()) / float64(pod.NodeAllocatableCpuQty.MilliValue()) * 100
+			}
+		}
+		cpuColor := ui.GetResourcePercentageColor(cpuPercent)
+		p.addResourceRowWithSparkline("CPU Usage", cpuCapacity, cpuUsage, cpuPercent, cpuColor, cpuHistory)
+
+		// Memory usage
+		memUsage := ""
+		memCapacity := ""
+		memPercent := 0.0
+		if pod.PodUsageMemQty != nil {
+			memUsage = ui.FormatMemory(pod.PodUsageMemQty)
+		}
+		if pod.NodeAllocatableMemQty != nil && pod.NodeAllocatableMemQty.Value() > 0 {
+			memCapacity = ui.FormatMemory(pod.NodeAllocatableMemQty)
+			if pod.PodUsageMemQty != nil {
+				memPercent = float64(pod.PodUsageMemQty.Value()) / float64(pod.NodeAllocatableMemQty.Value()) * 100
+			}
+		}
+		memColor := ui.GetResourcePercentageColor(memPercent)
+		p.addResourceRowWithSparkline("Mem Usage", memCapacity, memUsage, memPercent, memColor, memHistory)
+	}
+
+	// Requests/Limits sub-header
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  [gray]Requests/Limits:[-]").SetSelectable(false))
+	p.rowIndex++
+
+	// Header row
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  CONTAINER").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("CPU REQ").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell("CPU LIM").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 3, tview.NewTableCell("MEM REQ").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 4, tview.NewTableCell("MEM LIM").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.rowIndex++
+
+	for _, container := range containers {
+		cpuReq := container.CPURequest
+		if cpuReq == "" {
+			cpuReq = "-"
+		}
+		cpuLim := container.CPULimit
+		if cpuLim == "" {
+			cpuLim = "-"
+		}
+		memReq := container.MemoryRequest
+		if memReq == "" {
+			memReq = "-"
+		}
+		memLim := container.MemoryLimit
+		if memLim == "" {
+			memLim = "-"
+		}
+
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+container.Name).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(cpuReq).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(cpuLim).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 3, tview.NewTableCell(memReq).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 4, tview.NewTableCell(memLim).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.rowIndex++
+	}
+}
+
+// buildCPUHistory converts MetricSample CPU ratios to ResourceHistory format
+func (p *DetailPanel) buildCPUHistory(samples []model.MetricSample) *metrics.ResourceHistory {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	history := &metrics.ResourceHistory{
+		Resource:   metrics.ResourceCPU,
+		DataPoints: make([]metrics.HistoryDataPoint, len(samples)),
+		MinValue:   0,
+		MaxValue:   1, // Ratios are 0-1
+	}
+
+	for i, sample := range samples {
+		history.DataPoints[i] = metrics.HistoryDataPoint{
+			Timestamp: time.Unix(sample.Timestamp, 0),
+			Value:     sample.CPURatio, // Already 0-1 ratio
+		}
+	}
+
+	return history
+}
+
+// buildMemHistory converts MetricSample Memory ratios to ResourceHistory format
+func (p *DetailPanel) buildMemHistory(samples []model.MetricSample) *metrics.ResourceHistory {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	history := &metrics.ResourceHistory{
+		Resource:   metrics.ResourceMemory,
+		DataPoints: make([]metrics.HistoryDataPoint, len(samples)),
+		MinValue:   0,
+		MaxValue:   1, // Ratios are 0-1
+	}
+
+	for i, sample := range samples {
+		history.DataPoints[i] = metrics.HistoryDataPoint{
+			Timestamp: time.Unix(sample.Timestamp, 0),
+			Value:     sample.MemRatio, // Already 0-1 ratio
+		}
+	}
+
+	return history
+}
+
+// addResourceRowWithSparkline adds a resource usage row with sparkline graph
+func (p *DetailPanel) addResourceRowWithSparkline(name, capacity, usage string, percent float64, percentColor string, history *metrics.ResourceHistory) {
+	colorKeys := ui.ColorKeys{0: "olivedrab", 50: "yellow", 90: "red"}
+
+	// Use SparkGraph with history if available, otherwise fallback to empty graph
+	sparkGraph := ui.SparkGraph(15, history, ui.Ratio(percent/100), colorKeys)
+
+	// Add trend indicator if we have history
+	trend := ""
+	if history != nil && len(history.DataPoints) >= 2 {
+		trend = ui.SparkGraphTrend(history)
+	}
+
+	percentStr := fmt.Sprintf("[%s]%5.1f%%[-]", percentColor, percent)
+	capacityStr := ""
+	if capacity != "" {
+		capacityStr = fmt.Sprintf(" / %s", capacity)
+	}
+
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+name+":").SetTextColor(tcell.ColorGray).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(fmt.Sprintf("[%s] %s %s", sparkGraph, percentStr, trend)).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(fmt.Sprintf("Used: %s%s", usage, capacityStr)).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+	p.rowIndex++
+}
+
+// drawVolumesSection draws the volumes section
+func (p *DetailPanel) drawVolumesSection() {
+	volumes := p.data.GetVolumes()
+	if len(volumes) == 0 {
+		return
+	}
+
+	p.addSectionHeader(fmt.Sprintf("Volumes (%d)", len(volumes)))
+
+	// Header row
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  NAME").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("TYPE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell("MOUNT PATH").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 3, tview.NewTableCell("RO").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.rowIndex++
+
+	for _, vol := range volumes {
+		roStr := "No"
+		roColor := tcell.ColorGreen
+		if vol.ReadOnly {
+			roStr = "Yes"
+			roColor = tcell.ColorYellow
+		}
+
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+vol.Name).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(vol.Type).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(vol.MountPath).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 3, tview.NewTableCell(roStr).SetTextColor(roColor).SetSelectable(false))
+		p.rowIndex++
+	}
+}
+
+// drawConditionsSection draws the pod conditions
+func (p *DetailPanel) drawConditionsSection() {
+	conditions := p.data.GetConditions()
+	if len(conditions) == 0 {
+		return
+	}
+
+	p.addSectionHeader("Conditions")
+
+	// Header row
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  TYPE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("STATUS").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell("REASON").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.rowIndex++
+
+	for _, cond := range conditions {
+		statusColor := tcell.ColorGreen
+		if !cond.Healthy {
+			statusColor = tcell.ColorRed
+		}
+
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+cond.Type).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(cond.Status).SetTextColor(statusColor).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(cond.Reason).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.rowIndex++
+	}
+}
+
+// drawEventsSection draws recent events for this pod
+func (p *DetailPanel) drawEventsSection() {
+	if p.data == nil || len(p.data.Events) == 0 {
+		return
+	}
+
+	p.addSectionHeader(fmt.Sprintf("Events (%d)", len(p.data.Events)))
+
+	// Header row
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  TYPE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 1, tview.NewTableCell("REASON").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 2, tview.NewTableCell("MESSAGE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.table.SetCell(p.rowIndex, 3, tview.NewTableCell("AGE").SetTextColor(tcell.ColorYellow).SetSelectable(false))
+	p.rowIndex++
+
+	// Show last 10 events
+	maxEvents := 10
+	startIdx := 0
+	if len(p.data.Events) > maxEvents {
+		startIdx = len(p.data.Events) - maxEvents
+	}
+
+	for i := startIdx; i < len(p.data.Events); i++ {
+		event := p.data.Events[i]
+		typeColor := tcell.ColorGreen
+		if event.Type == "Warning" {
+			typeColor = tcell.ColorYellow
+		}
+
+		// Truncate message if too long
+		message := event.Message
+		if len(message) > 60 {
+			message = message[:57] + "..."
+		}
+
+		age := formatEventAge(event)
+
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+event.Type).SetTextColor(typeColor).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(event.Reason).SetTextColor(tcell.ColorWhite).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 2, tview.NewTableCell(message).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 3, tview.NewTableCell(age).SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.rowIndex++
+	}
+}
+
+// drawLabelsSection draws the pod labels
+func (p *DetailPanel) drawLabelsSection() {
+	labels := p.data.GetLabels()
+	if len(labels) == 0 {
+		return
+	}
+
+	p.addSectionHeader(fmt.Sprintf("Labels (%d)", len(labels)))
+
+	for key, value := range labels {
+		p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("  "+key+":").SetTextColor(tcell.ColorGray).SetSelectable(false))
+		p.table.SetCell(p.rowIndex, 1, tview.NewTableCell(value).SetTextColor(tcell.ColorWhite).SetSelectable(false).SetExpansion(3))
+		p.rowIndex++
+	}
+}
+
+// Helper methods
+
+func (p *DetailPanel) addSectionHeader(title string) {
+	// Add a separator line before section (except for first section)
+	if p.rowIndex > 0 {
+		p.addSeparatorRow()
+	}
+
+	cell := tview.NewTableCell(fmt.Sprintf("[::b]▶ %s[-::-]", title)).
+		SetTextColor(tcell.ColorAqua).
+		SetSelectable(false).
+		SetExpansion(1)
+	p.table.SetCell(p.rowIndex, 0, cell)
+	p.rowIndex++
+}
+
+func (p *DetailPanel) addSeparatorRow() {
+	// Visual separator using dim line
+	separator := tview.NewTableCell("[gray]────────────────────────────────────────────────────────────────────────────────[-]").
+		SetSelectable(false).
+		SetExpansion(1)
+	p.table.SetCell(p.rowIndex, 0, separator)
+	p.rowIndex++
+}
+
+func (p *DetailPanel) addKeyValue(key, value string) {
+	keyCell := tview.NewTableCell("  " + key + ":").
+		SetTextColor(tcell.ColorGray).
+		SetSelectable(false)
+	valueCell := tview.NewTableCell(value).
+		SetTextColor(tcell.ColorWhite).
+		SetSelectable(false)
+
+	p.table.SetCell(p.rowIndex, 0, keyCell)
+	p.table.SetCell(p.rowIndex, 1, valueCell)
+	p.rowIndex++
+}
+
+func (p *DetailPanel) addEmptyRow() {
+	p.table.SetCell(p.rowIndex, 0, tview.NewTableCell("").SetSelectable(false))
+	p.rowIndex++
+}
+
+func formatEventAge(event corev1.Event) string {
+	// Calculate age from event timestamp
+	var eventTime time.Time
+	if !event.LastTimestamp.IsZero() {
+		eventTime = event.LastTimestamp.Time
+	} else if !event.EventTime.IsZero() {
+		eventTime = event.EventTime.Time
+	} else if !event.FirstTimestamp.IsZero() {
+		eventTime = event.FirstTimestamp.Time
+	} else {
+		return "unknown"
+	}
+
+	duration := time.Since(eventTime)
+	if duration < time.Minute {
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	} else if duration < time.Hour {
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	} else if duration < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(duration.Hours()/24))
+}
+
+// DrawFooter draws the footer
+func (p *DetailPanel) DrawFooter(_ interface{}) {}
+
+// Clear clears the panel
+func (p *DetailPanel) Clear() {
+	p.table.Clear()
+}
+
+// GetRootView returns the root view
+func (p *DetailPanel) GetRootView() tview.Primitive {
+	return p.root
+}
+
+// GetChildrenViews returns child views
+func (p *DetailPanel) GetChildrenViews() []tview.Primitive {
+	return nil
+}
+
+// SetFocused implements ui.FocusablePanel
+func (p *DetailPanel) SetFocused(focused bool) {
+	ui.SetFlexFocused(p.root, focused)
+}
+
+// HasEscapableState implements ui.EscapablePanel
+func (p *DetailPanel) HasEscapableState() bool {
+	return true // Always allow ESC to go back
+}
+
+// HandleEscape implements ui.EscapablePanel
+func (p *DetailPanel) HandleEscape() bool {
+	if p.onBack != nil {
+		p.onBack()
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
  Add live CPU and memory usage metrics to the Pod/Container Detail pages.

  Container Detail Panel (Resources section):
  - Showing actual container resource consumption with refresh updates
  - Metrics refresh automatically with each data update cycle

  Pod Detail Page :
  - Updated container table to add CPU and MEM columns 

  Static Pod Support:
  - Implemented an aggregated fallback for single-container static pods (kube-apiserver, etcd, etc.)
  - Fixes metrics display where cAdvisor reports aggregate metrics without container name

  Refresh Architecture Update:
  - Pre-fetch metrics outside QueueUpdateDraw to avoid blocking UI thread
  - Added UpdateMetrics(cpu, mem) method for concurrency-safe UI updates