### PR TITLE
issue-148: User Session Dir and Logging

### DIFF
--- a/application/app_ctrl.go
+++ b/application/app_ctrl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -40,9 +41,9 @@ type Application struct {
 	navStack *NavigationStack
 
 	// Detail view callbacks
-	nodeDetailCallback     func(nodeName string)
-	podDetailCallback      func(namespace, podName string)
-	containerLogsCallback  func(namespace, podName, containerName string)
+	nodeDetailCallback    func(nodeName string)
+	podDetailCallback     func(namespace, podName string)
+	containerLogsCallback func(namespace, podName, containerName string)
 
 	// Health state tracking for transitions
 	lastHealthyState      bool
@@ -558,6 +559,7 @@ func (app *Application) Run(ctx context.Context) error {
 
 	// setup application UI
 	if err := app.setup(ctx); err != nil {
+		slog.Error("application setup failed", "error", err)
 		return err
 	}
 
@@ -568,6 +570,7 @@ func (app *Application) Run(ctx context.Context) error {
 		}
 	}()
 
+	slog.Info("tui started", "pages", app.getPageTitles())
 	return app.tviewApp.Run()
 }
 
@@ -576,7 +579,7 @@ func (app *Application) Stop() error {
 		return errors.New("failed to stop, tview.Application nil")
 	}
 	app.tviewApp.Stop()
-	fmt.Println("ktop finished")
+	slog.Info("ktop stopped")
 	return nil
 }
 
@@ -603,7 +606,7 @@ func (app *Application) handleMetricsHealthChange(healthy bool, info metrics.Sou
 	}
 
 	// Debouncing constants (prevents flapping during server restart)
-	const requiredConsecOK = 2            // Require 2 consecutive successes
+	const requiredConsecOK = 2               // Require 2 consecutive successes
 	const minUnhealthyTime = 5 * time.Second // Must be unhealthy for at least 5s before recovery
 
 	// Update header immediately
@@ -644,6 +647,7 @@ func (app *Application) handleMetricsHealthChange(healthy bool, info metrics.Sou
 				ui.ToastSuccess,
 				3*time.Second,
 			)
+			slog.Info("metrics source healthy", "source", info.Type)
 			app.lastHealthyState = true
 		}
 	} else {
@@ -658,6 +662,7 @@ func (app *Application) handleMetricsHealthChange(healthy bool, info metrics.Sou
 				ui.ToastError,
 				5*time.Second,
 			)
+			slog.Warn("metrics source unhealthy", "source", info.Type)
 			app.lastHealthyState = false
 		}
 	}
@@ -942,4 +947,3 @@ func (app *Application) updateFooterContext() {
 func (app *Application) SetFooterContext(ctx ui.FooterContext) {
 	app.panel.setFooterContext(ctx)
 }
-

--- a/application/app_ui.go
+++ b/application/app_ui.go
@@ -24,8 +24,8 @@ type appPanel struct {
 	title           string
 	header          *tview.Table
 	pages           *tview.Pages
-	footer          *tview.Table    // Legacy footer for page buttons (future use)
-	footerComponent *ui.Footer      // Context-aware navigation footer
+	footer          *tview.Table // Legacy footer for page buttons (future use)
+	footerComponent *ui.Footer   // Context-aware navigation footer
 	modals          []tview.Primitive
 	root            *tview.Pages // CHANGED: from *tview.Flex to *tview.Pages
 
@@ -71,8 +71,8 @@ func (p *appPanel) Layout(data interface{}) {
 
 	// Existing layout with navigation footer
 	mainLayout := tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(p.header, 3, 1, true).                   // header - focusable for input handling
-		AddItem(p.pages, 0, 1, true).                    // body
+		AddItem(p.header, 3, 1, true).                    // header - focusable for input handling
+		AddItem(p.pages, 0, 1, true).                     // body
 		AddItem(p.footerComponent.GetView(), 3, 0, false) // navigation footer - 3 rows for border
 
 	// NEW: Wrap in Pages for toast layering

--- a/application/navigation.go
+++ b/application/navigation.go
@@ -4,10 +4,10 @@ package application
 type PageType string
 
 const (
-	PageOverview       PageType = "overview"
-	PageNodeDetail     PageType = "node_detail"
-	PagePodDetail      PageType = "pod_detail"
-	PageContainerLogs  PageType = "container_logs"
+	PageOverview      PageType = "overview"
+	PageNodeDetail    PageType = "node_detail"
+	PagePodDetail     PageType = "pod_detail"
+	PageContainerLogs PageType = "container_logs"
 )
 
 // PageState represents a page in the navigation stack

--- a/cmd/ktop.go
+++ b/cmd/ktop.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +13,9 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/spf13/cobra"
 	"github.com/vladimirvivien/ktop/application"
+	"github.com/vladimirvivien/ktop/buildinfo"
 	"github.com/vladimirvivien/ktop/config"
+	"github.com/vladimirvivien/ktop/internal/logging"
 	"github.com/vladimirvivien/ktop/k8s"
 	"github.com/vladimirvivien/ktop/metrics"
 	k8sMetrics "github.com/vladimirvivien/ktop/metrics/k8s"
@@ -55,6 +59,10 @@ type ktopCmdOptions struct {
 	prometheusRetention      string
 	prometheusMaxSamples     int
 	prometheusComponents     []string
+
+	// Logging configuration
+	logLevel  string
+	logFormat string
 }
 
 // NewKtopCmd returns a command for ktop
@@ -95,6 +103,12 @@ func NewKtopCmd() *cobra.Command {
 		[]string{"kubelet", "cadvisor"},
 		"Kubernetes components to scrape (comma-separated: kubelet,cadvisor,apiserver,etcd,scheduler,controller-manager,kube-proxy)")
 
+	// Logging flags
+	cmd.Flags().StringVar(&o.logLevel, "log-level", "info",
+		"Log verbosity: debug, info, warn, error")
+	cmd.Flags().StringVar(&o.logFormat, "log-format", "text",
+		"Log record format: text or json")
+
 	o.kubeFlags.AddFlags(cmd.Flags())
 	return cmd
 }
@@ -130,29 +144,29 @@ func selectMetricsSource(
 ) (metrics.MetricsSource, *promMetrics.PromMetricsSource, error) {
 	switch sourceType {
 	case "prometheus":
-		fmt.Print("Connecting to Prometheus... ")
+		slog.Info("connecting to metrics source", "source", "prometheus")
 		promSource, err := tryPrometheus(ctx, k8sC.RESTConfig(), promConfig)
 		if err == nil {
-			fmt.Println("✓")
+			slog.Info("metrics source ready", "source", "prometheus")
 			return promSource, promSource, nil
 		}
-		fmt.Println("✗")
 		if !enableFallback {
+			slog.Error("prometheus required but unreachable", "error", err)
 			return nil, nil, fmt.Errorf("prometheus not available: %v", err)
 		}
-		fmt.Print("Falling back to Metrics Server... ")
+		slog.Warn("prometheus unavailable, falling back to metrics-server", "error", err)
 		source := k8sMetrics.NewMetricsServerSource(k8sC.Controller())
-		fmt.Println("✓")
+		slog.Info("metrics source ready", "source", "metrics-server", "reason", "prometheus-fallback")
 		return source, nil, nil
 
 	case "metrics-server":
-		fmt.Print("Connecting to Metrics Server... ")
+		slog.Info("connecting to metrics source", "source", "metrics-server")
 		source := k8sMetrics.NewMetricsServerSource(k8sC.Controller())
-		fmt.Println("✓")
+		slog.Info("metrics source ready", "source", "metrics-server")
 		return source, nil, nil
 
 	case "none":
-		fmt.Println("Using metrics source: None")
+		slog.Info("metrics source disabled", "source", "none")
 		return nil, nil, nil
 
 	default:
@@ -163,6 +177,26 @@ func selectMetricsSource(
 func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Initialize structured logging before any other work so subsequent
+	// diagnostics land in ~/.ktop/ktop.log. A failure here is non-fatal:
+	// ktop continues with logging silenced rather than letting slog
+	// fall back to stderr (which would corrupt the TUI).
+	logCloser, err := logging.Init(logging.Config{
+		Level:  o.logLevel,
+		Format: o.logFormat,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ktop: logging disabled: %v\n", err)
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	}
+	defer func() { _ = logCloser.Close() }()
+
+	slog.Info("ktop starting",
+		"version", buildinfo.Version,
+		"log_level", o.logLevel,
+		"metrics_source", o.metricsSource,
+	)
 
 	if o.allNamespaces {
 		o.namespace = k8s.AllNamespaces
@@ -177,6 +211,7 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	if c.Flags().Changed("prometheus-scrape-interval") {
 		interval, err := time.ParseDuration(o.prometheusScrapeInterval)
 		if err != nil {
+			slog.Error("invalid prometheus-scrape-interval", "value", o.prometheusScrapeInterval, "error", err)
 			return fmt.Errorf("invalid prometheus-scrape-interval: %w", err)
 		}
 		cfg.Prometheus.ScrapeInterval = interval
@@ -185,6 +220,7 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	if c.Flags().Changed("prometheus-retention") {
 		retention, err := time.ParseDuration(o.prometheusRetention)
 		if err != nil {
+			slog.Error("invalid prometheus-retention", "value", o.prometheusRetention, "error", err)
 			return fmt.Errorf("invalid prometheus-retention: %w", err)
 		}
 		cfg.Prometheus.RetentionTime = retention
@@ -197,6 +233,7 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	if c.Flags().Changed("prometheus-components") {
 		components, err := config.ParseComponents(o.prometheusComponents)
 		if err != nil {
+			slog.Error("invalid prometheus-components", "value", o.prometheusComponents, "error", err)
 			return fmt.Errorf("invalid prometheus-components: %w", err)
 		}
 		cfg.Prometheus.Components = components
@@ -204,14 +241,16 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 
 	// Validate configuration
 	if err := cfg.Validate(); err != nil {
+		slog.Error("invalid configuration", "error", err)
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	k8sC, err := k8s.New(o.kubeFlags)
 	if err != nil {
+		slog.Error("kubernetes client creation failed", "error", err)
 		return fmt.Errorf("ktop: failed to create Kubernetes client: %s", err)
 	}
-	fmt.Printf("Connected to: %s\n", k8sC.RESTConfig().Host)
+	slog.Info("cluster connected", "host", k8sC.RESTConfig().Host)
 
 	// Initialize metrics source based on configuration
 	// Fallback is enabled only when using default (not explicitly set)
@@ -257,8 +296,10 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	app.AddPage(overview.NewWithColumnOptions(app, "Overview", o.showAllColumns, nodeColumns, podColumns))
 
 	if err := k8sC.AssertCoreAuthz(ctx); err != nil {
+		slog.Error("kubernetes authorization check failed", "error", err)
 		return fmt.Errorf("ktop: %s", err)
 	}
+	slog.Info("kubernetes authorization checks passed")
 
 	// Check terminal height before starting TUI
 	screen, err := tcell.NewScreen()
@@ -267,6 +308,7 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 			_, height := screen.Size()
 			screen.Fini()
 			if height < ui.MinTerminalHeight {
+				slog.Error("terminal too small", "height", height, "min", ui.MinTerminalHeight)
 				return fmt.Errorf("terminal height too small (%d rows). Minimum required: %d rows", height, ui.MinTerminalHeight)
 			}
 		}
@@ -281,7 +323,7 @@ func (o *ktopCmdOptions) runKtop(c *cobra.Command, args []string) error {
 	select {
 	case err := <-appErr:
 		if err != nil {
-			fmt.Printf("app error: %s\n", err)
+			slog.Error("application exited with error", "error", err)
 			os.Exit(1)
 		}
 	case <-ctx.Done():

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/rivo/tview v0.0.0-20211202162923-2a6de950f73b
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/api v0.27.4
 	k8s.io/apimachinery v0.27.4
 	k8s.io/cli-runtime v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -830,6 +830,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,134 @@
+// Package logging configures the process-wide structured logger and routes
+// records to a rotating file under the user's ktop directory.
+//
+// The TUI cannot write to stdout/stderr without corrupting its display, so
+// diagnostic logs go to ~/.ktop/ktop.log by default. Init wires this once
+// at startup; the rest of the program calls slog through the default logger.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vladimirvivien/ktop/internal/userdir"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	// LogFileName is the rotating log file name inside the ktop directory.
+	LogFileName = "ktop.log"
+
+	logFileMode = 0o600
+
+	// DefaultMaxSize is the size in MB at which the log rotates.
+	DefaultMaxSize = 10
+	// DefaultMaxBackups is the number of rotated log files retained.
+	DefaultMaxBackups = 3
+)
+
+// Destination selects where log records are written.
+type Destination string
+
+const (
+	// DestFile routes logs to ~/.ktop/ktop.log (the default).
+	DestFile Destination = "file"
+	// DestStderr routes logs to standard error. Reserved for v0.6.1's
+	// --noui --log=stderr flag; the handler supports it today.
+	DestStderr Destination = "stderr"
+)
+
+// Config controls log level, format, and destination.
+type Config struct {
+	Level    string      // "debug" | "info" | "warn" | "error"; empty = info
+	Format   string      // "text" | "json"; empty = text
+	Dest     Destination // DestFile (default) or DestStderr
+	Filename string      // override the default file path; ignored when Dest is stderr
+}
+
+// Init configures slog's default logger from cfg and returns an io.Closer that
+// the caller should close on shutdown. The returned closer is always non-nil
+// even on error, so callers can defer Close() unconditionally.
+func Init(cfg Config) (io.Closer, error) {
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		return nopCloser{}, err
+	}
+
+	writer, closer, err := openSink(cfg)
+	if err != nil {
+		return nopCloser{}, err
+	}
+
+	handler, err := makeHandler(writer, cfg.Format, level)
+	if err != nil {
+		return closer, err
+	}
+	slog.SetDefault(slog.New(handler))
+	return closer, nil
+}
+
+func parseLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level: %s", s)
+	}
+}
+
+func openSink(cfg Config) (io.Writer, io.Closer, error) {
+	if cfg.Dest == DestStderr {
+		return os.Stderr, nopCloser{}, nil
+	}
+
+	path := cfg.Filename
+	if path == "" {
+		dir, err := userdir.Ensure()
+		if err != nil {
+			return nil, nopCloser{}, err
+		}
+		path = filepath.Join(dir, LogFileName)
+	}
+
+	// Touch the file ourselves so it inherits 0600; lumberjack reuses
+	// the existing inode and preserves the permission bits.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, logFileMode)
+	if err != nil {
+		return nil, nopCloser{}, fmt.Errorf("open log file %s: %w", path, err)
+	}
+	_ = f.Close()
+
+	lj := &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    DefaultMaxSize,
+		MaxBackups: DefaultMaxBackups,
+		Compress:   false,
+	}
+	return lj, lj, nil
+}
+
+func makeHandler(w io.Writer, format string, level slog.Level) (slog.Handler, error) {
+	opts := &slog.HandlerOptions{Level: level}
+	switch strings.ToLower(format) {
+	case "", "text":
+		return slog.NewTextHandler(w, opts), nil
+	case "json":
+		return slog.NewJSONHandler(w, opts), nil
+	default:
+		return nil, fmt.Errorf("unknown log format: %s", format)
+	}
+}
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,123 @@
+package logging
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    slog.Level
+		wantErr bool
+	}{
+		{"", slog.LevelInfo, false},
+		{"info", slog.LevelInfo, false},
+		{"INFO", slog.LevelInfo, false},
+		{"debug", slog.LevelDebug, false},
+		{"warn", slog.LevelWarn, false},
+		{"warning", slog.LevelWarn, false},
+		{"error", slog.LevelError, false},
+		{"trace", slog.LevelInfo, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseLevel(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseLevel(%q) err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("parseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMakeHandler_FormatSelection(t *testing.T) {
+	var buf bytes.Buffer
+
+	text, err := makeHandler(&buf, "text", slog.LevelInfo)
+	if err != nil {
+		t.Fatalf("text handler error: %v", err)
+	}
+	if _, ok := text.(*slog.TextHandler); !ok {
+		t.Errorf("text format produced %T, want *slog.TextHandler", text)
+	}
+
+	json, err := makeHandler(&buf, "json", slog.LevelInfo)
+	if err != nil {
+		t.Fatalf("json handler error: %v", err)
+	}
+	if _, ok := json.(*slog.JSONHandler); !ok {
+		t.Errorf("json format produced %T, want *slog.JSONHandler", json)
+	}
+
+	if _, err := makeHandler(&buf, "yaml", slog.LevelInfo); err == nil {
+		t.Errorf("makeHandler(yaml) = nil error, want error")
+	}
+}
+
+func TestInit_WritesToFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KTOP_DIR", dir)
+
+	closer, err := Init(Config{Level: "debug", Format: "text"})
+	if err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	slog.Info("test record", "key", "value")
+
+	// lumberjack writes synchronously; close to flush before reading.
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	path := filepath.Join(dir, LogFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(data), "test record") {
+		t.Errorf("log file did not contain expected record; got: %s", data)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("log file mode = %v, want 0600", mode)
+	}
+}
+
+func TestInit_StderrDestination(t *testing.T) {
+	// Redirect stderr so we can capture it.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	closer, err := Init(Config{Level: "info", Format: "text", Dest: DestStderr})
+	if err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	slog.Info("stderr record")
+	_ = w.Close()
+
+	captured, _ := io.ReadAll(r)
+	if !strings.Contains(string(captured), "stderr record") {
+		t.Errorf("stderr did not contain expected record; got: %s", captured)
+	}
+}

--- a/internal/userdir/dir.go
+++ b/internal/userdir/dir.go
@@ -1,0 +1,45 @@
+// Package userdir resolves and provisions the per-user ktop directory
+// (default ~/.ktop), where ktop stores its log file and, from v0.6.3,
+// its config file. Honor $KTOP_DIR to relocate the entire tree.
+package userdir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// EnvVar is the environment variable that overrides the default location.
+const EnvVar = "KTOP_DIR"
+
+const dirMode = 0o700
+
+// Path returns the resolved ktop directory path. It does not create the
+// directory; use Ensure for that.
+//
+// Resolution order:
+//  1. $KTOP_DIR if set and non-empty
+//  2. $HOME/.ktop
+func Path() (string, error) {
+	if dir := os.Getenv(EnvVar); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home directory unavailable: %w", err)
+	}
+	return filepath.Join(home, ".ktop"), nil
+}
+
+// Ensure resolves the ktop directory and creates it (mode 0700) if missing.
+// Returns the resolved path on success.
+func Ensure() (string, error) {
+	dir, err := Path()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return "", fmt.Errorf("create %s: %w", dir, err)
+	}
+	return dir, nil
+}

--- a/internal/userdir/dir_test.go
+++ b/internal/userdir/dir_test.go
@@ -1,0 +1,74 @@
+package userdir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath_EnvOverride(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "custom-ktop")
+	t.Setenv(EnvVar, want)
+
+	got, err := Path()
+	if err != nil {
+		t.Fatalf("Path() error: %v", err)
+	}
+	if got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestPath_DefaultsToHome(t *testing.T) {
+	t.Setenv(EnvVar, "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("user home dir unavailable: %v", err)
+	}
+	want := filepath.Join(home, ".ktop")
+
+	got, err := Path()
+	if err != nil {
+		t.Fatalf("Path() error: %v", err)
+	}
+	if got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestEnsure_CreatesDirectoryWithMode0700(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ktop")
+	t.Setenv(EnvVar, dir)
+
+	got, err := Ensure()
+	if err != nil {
+		t.Fatalf("Ensure() error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("Ensure() returned %q, want %q", got, dir)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%s is not a directory", dir)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Errorf("dir mode = %v, want 0700", mode)
+	}
+}
+
+func TestEnsure_IsIdempotent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ktop")
+	t.Setenv(EnvVar, dir)
+
+	if _, err := Ensure(); err != nil {
+		t.Fatalf("first Ensure() error: %v", err)
+	}
+	if _, err := Ensure(); err != nil {
+		t.Fatalf("second Ensure() error: %v", err)
+	}
+}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -220,4 +220,3 @@ func (k8s *Client) AssertCoreAuthz(ctx context.Context) error {
 
 	return nil
 }
-

--- a/k8s/client_controller.go
+++ b/k8s/client_controller.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"errors"
-	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/vladimirvivien/ktop/health"
@@ -167,7 +167,7 @@ func (c *Controller) Start(ctx context.Context, resync time.Duration) error {
 	); !ok {
 		// Timeout or error - continue anyway with graceful degradation
 		// UI will render with empty/partial data initially
-		fmt.Println("Note: Initial data sync still in progress, UI may show partial data briefly")
+		slog.Warn("initial informer cache sync incomplete; continuing with partial data")
 	}
 
 	// defer waiting for non-core resources to sync

--- a/prom/controller.go
+++ b/prom/controller.go
@@ -3,6 +3,7 @@ package prom
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -44,6 +45,12 @@ func (cc *CollectorController) Start(ctx context.Context) error {
 	// Start component discovery (for periodic re-discovery)
 	go cc.runComponentDiscovery(ctx)
 
+	slog.Info("prometheus collector started",
+		"scrape_interval", cc.config.Interval,
+		"retention", cc.config.RetentionTime,
+		"max_samples", cc.config.MaxSamples,
+		"components", cc.config.Components,
+	)
 	return nil
 }
 
@@ -58,6 +65,7 @@ func (cc *CollectorController) Stop() error {
 
 	cc.running = false
 
+	slog.Info("prometheus collector stopped")
 	// Cleanup would be handled by context cancellation
 	return nil
 }
@@ -169,6 +177,10 @@ func (cc *CollectorController) collectFromComponent(ctx context.Context, compone
 	metrics, err := cc.collector.ScrapeComponent(ctx, component)
 	if err != nil {
 		cc.setLastError(err)
+		slog.Warn("component scrape failed (will retry)",
+			"component", component,
+			"error", err,
+		)
 		if cc.onError != nil {
 			cc.onError(component, err)
 		}
@@ -178,6 +190,10 @@ func (cc *CollectorController) collectFromComponent(ctx context.Context, compone
 	// Store the metrics
 	if err := cc.store.AddMetrics(metrics); err != nil {
 		cc.setLastError(err)
+		slog.Warn("storing scraped metrics failed",
+			"component", component,
+			"error", err,
+		)
 		if cc.onError != nil {
 			cc.onError(component, err)
 		}


### PR DESCRIPTION
Introduces ~/.ktop to stor user-session files. This patch also introduces a logging infrastructure (basedon slog) to create/rotate logs stored in ~/.ktop/ktop.log.

Fixe #148 