### PR TITLE
Issue-150 Support for PSI Metrics

### DIFF
--- a/application/app_ctrl.go
+++ b/application/app_ctrl.go
@@ -672,6 +672,8 @@ func (app *Application) handleMetricsHealthChange(healthy bool, info metrics.Sou
 // namespaceDisplay is the namespace value to show (may include filter styling)
 func (app *Application) buildHeaderString(namespaceDisplay string) string {
 	var hdr strings.Builder
+	client := app.GetK8sClient()
+
 	// Format: Context: name | K8s: version | User: user | Namespace: value | Metrics: status
 	hdr.WriteString("[green]Context: [white]%s [green]| K8s: [white]%s [green]| User: [white]%s [green]| Namespace: [white]%s [green]| Metrics:")
 
@@ -682,8 +684,6 @@ func (app *Application) buildHeaderString(namespaceDisplay string) string {
 	} else {
 		hdr.WriteString(" [red]not connected")
 	}
-
-	client := app.GetK8sClient()
 
 	// Truncate long values to prevent header overflow
 	context := truncateString(client.ClusterName(), 25)

--- a/docs/psi.md
+++ b/docs/psi.md
@@ -1,0 +1,90 @@
+# PSI Metrics
+
+Pressure Stall Information measures the percentage of wall time a cgroup spent with at least one task blocked waiting on a resource. ktop surfaces PSI in a `STALL` column on the Pods and Nodes tables and as an aggregate `Stall:` value on the cluster summary strip.
+
+PSI distinguishes a healthy busy workload from a throttled one — a signal that pure utilization metrics (`kubectl top`-style CPU%) cannot show.
+
+## What the cell shows
+
+```
+IO 1.15%    I/O bound (e.g. etcd writing to disk)
+CPU 0.24%   CPU bound (scheduler hot path, throttled cgroup)
+MEM 8.0%    memory bound (page-cache pressure, swapping)
+·           genuinely zero
+```
+
+The label names the dominant axis — whichever of CPU / MEM / IO has the highest stall percentage at this moment. Colors:
+
+| Range | Color |
+|-------|-------|
+| < 2% | green |
+| 2 – 10% | yellow |
+| 10 – 25% | orange |
+| ≥ 25% | red |
+
+## Why PSI, not just CPU%
+
+| Pod state | `kubectl top` CPU | STALL | Interpretation |
+|-----------|------------------|-------|----------------|
+| Healthy busy | 80% | 0% | Using its allocation, getting work done |
+| **Throttled** | 30% | CPU 15% | **Wants CPU, isn't getting it** — cgroup limit or noisy neighbor |
+| Memory-pressured | 40% | MEM 8% | Waiting on page faults / reclaim |
+| Disk-bound | 20% | IO 12% | Storage backlog |
+| Idle | 5% | · | Healthy |
+
+The Healthy-busy and Throttled rows are indistinguishable by CPU% alone. STALL separates them.
+
+## Aggregation
+
+- **Per pod** — MAX across the pod's containers per axis. A pod with one stalled container surfaces that container's number; idle siblings do not dilute it.
+- **Per node** — the node's root cgroup (`id="/"` in cAdvisor labels). Whole-node stall.
+- **Cluster summary `Stall:`** — mean across nodes per axis, then dominant-axis selection. Average is the right cluster-wide health number; the per-node row still shows the individual worst-affected nodes.
+
+## Sorting
+
+Press `l` while focused on the Pods or Nodes table to sort by the dominant stall axis. Press again to flip direction.
+
+## Requirements
+
+| Component | Required | Notes |
+|-----------|----------|-------|
+| Linux kernel | ≥ 4.20 | PSI was added in 4.20 |
+| cgroup version | v2 | Per-cgroup PSI requires cgroup v2 |
+| Kubernetes server | ≥ 1.34 (Beta), 1.36 (GA) | `KubeletPSI` feature gate enabled by default in 1.34; locked on in 1.36 |
+| Metrics source | Prometheus | Metrics-server does not surface PSI; STALL cells will read `·` everywhere |
+
+When the kernel on a node is older than 4.20, the per-row STALL cell is prefixed with a yellow `⚠` glyph because the underlying counters either don't exist or report best-effort values.
+
+## Caveat: K8s versions below 1.36
+
+PSI is GA in Kubernetes 1.36+ ([release blog](https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/)). Values are still shown on 1.34 and 1.35 clusters, but a [known kubelet bug](https://github.com/kubernetes/kubernetes/issues/136333) causes some pre-GA builds to emit zero-valued PSI metrics even when the host OS does not support PSI. Real zero and fake zero are indistinguishable at the metric layer. Use the procedure below to verify when a node's STALL column persistently reads `·` despite a busy workload.
+
+## Verifying PSI is live on a node
+
+```bash
+# Confirm the kernel exposes PSI
+kubectl debug node/<node-name> -it --image=busybox -- cat /proc/pressure/cpu
+
+# A working node returns three lines like:
+#   some avg10=0.00 avg60=0.04 avg300=0.07 total=12345678
+#   ...
+# If /proc/pressure/cpu does not exist, the kernel lacks PSI support.
+
+# Confirm kubelet is exporting PSI metrics
+kubectl get --raw "/api/v1/nodes/<node-name>/proxy/metrics/cadvisor" \
+  | grep -E '^container_pressure_(cpu|memory|io)_(waiting|stalled)_seconds_total' \
+  | head
+```
+
+If `/proc/pressure/cpu` exists but the metrics endpoint emits zeros only, your kubelet build is affected by the zero-emission bug; upgrade to 1.36 or a patched 1.34/1.35.
+
+## First-run behavior
+
+STALL cells populate after a **40-second warmup**. The stall rate is computed over a 40-second window; before the window fills, cells read `·` regardless of actual stall.
+
+## Reference
+
+- [Understand PSI Metrics — Kubernetes docs](https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/)
+- [Kubernetes 1.36 PSI GA announcement](https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/)
+- [KEP-4205: PSI Metric](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4205-psi-metric/README.md)
+- [Linux kernel PSI documentation](https://docs.kernel.org/accounting/psi.html)

--- a/health/api_health.go
+++ b/health/api_health.go
@@ -30,24 +30,24 @@ func (s APIState) String() string {
 
 // APIHealthTracker monitors Kubernetes API server health with retry logic
 type APIHealthTracker struct {
-	state             APIState
-	retryCount        int
-	maxRetries        int
-	baseBackoff       time.Duration
-	lastError         error
-	lastSuccessTime   time.Time
-	lastErrorTime     time.Time // Track when we last saw an error
-	retryTimer        *time.Timer
-	consecutiveOK     int           // Consecutive successful checks needed to recover
-	requiredConsecOK  int           // Number of consecutive OKs required before declaring healthy
-	minUnhealthyTime  time.Duration // Minimum time to stay unhealthy before recovery
-	mu                sync.RWMutex
+	state            APIState
+	retryCount       int
+	maxRetries       int
+	baseBackoff      time.Duration
+	lastError        error
+	lastSuccessTime  time.Time
+	lastErrorTime    time.Time // Track when we last saw an error
+	retryTimer       *time.Timer
+	consecutiveOK    int           // Consecutive successful checks needed to recover
+	requiredConsecOK int           // Number of consecutive OKs required before declaring healthy
+	minUnhealthyTime time.Duration // Minimum time to stay unhealthy before recovery
+	mu               sync.RWMutex
 
 	// Callbacks
-	onStateChange    func(APIState, string) // For toast notifications
-	onHealthy        func()                 // Resume normal operation
-	onDisconnected   func()                 // Zero out UI values
-	onTryReconnect   func()                 // Trigger immediate health check
+	onStateChange  func(APIState, string) // For toast notifications
+	onHealthy      func()                 // Resume normal operation
+	onDisconnected func()                 // Zero out UI values
+	onTryReconnect func()                 // Trigger immediate health check
 }
 
 // NewAPIHealthTracker creates a new health tracker with the given state change callback
@@ -58,7 +58,7 @@ func NewAPIHealthTracker(onStateChange func(APIState, string)) *APIHealthTracker
 		baseBackoff:      2 * time.Second,
 		lastSuccessTime:  time.Now(),
 		onStateChange:    onStateChange,
-		requiredConsecOK: 3,               // Require 3 consecutive successful checks before declaring healthy
+		requiredConsecOK: 3,                // Require 3 consecutive successful checks before declaring healthy
 		minUnhealthyTime: 10 * time.Second, // Must stay unhealthy for at least 10 seconds before recovery
 	}
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -36,8 +36,7 @@ type Destination string
 const (
 	// DestFile routes logs to ~/.ktop/ktop.log (the default).
 	DestFile Destination = "file"
-	// DestStderr routes logs to standard error. Reserved for v0.6.1's
-	// --noui --log=stderr flag; the handler supports it today.
+	// DestStderr routes logs to standard error.
 	DestStderr Destination = "stderr"
 )
 

--- a/internal/psi/version.go
+++ b/internal/psi/version.go
@@ -1,0 +1,75 @@
+// Package psi provides version-detection helpers for Pressure Stall
+// Information support. PSI requires Kubernetes 1.34+ for Beta access (subject
+// to the kubelet zero-emission bug, kubernetes/kubernetes#136333) and 1.36+
+// for GA. The Linux kernel must be at least 4.20.
+package psi
+
+import (
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+const gaMajor = 1
+const gaMinor = 36
+
+const kernelMajor = 4
+const kernelMinor = 20
+
+// ServerVersionOK reports whether the cluster server version is at or above
+// the PSI GA release (Kubernetes 1.36). Returns false on parse failure
+// (conservative default for unrecognized version strings).
+func ServerVersionOK(v *version.Info) bool {
+	if v == nil {
+		return false
+	}
+	major, err := strconv.Atoi(strings.TrimSuffix(v.Major, "+"))
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
+	if err != nil {
+		return false
+	}
+	if major > gaMajor {
+		return true
+	}
+	if major == gaMajor && minor >= gaMinor {
+		return true
+	}
+	return false
+}
+
+// KernelVersionOK reports whether the node's Linux kernel version supports
+// PSI (>= 4.20). The kernelVersion string is typically formatted as
+// "<major>.<minor>.<patch>-<flavor>" (e.g. "5.15.0-72-generic"). Returns false
+// on parse failure (conservative default for unrecognized version strings).
+func KernelVersionOK(kernelVersion string) bool {
+	if kernelVersion == "" {
+		return false
+	}
+	// Strip everything after the first '-' (distro flavor).
+	if i := strings.IndexByte(kernelVersion, '-'); i > 0 {
+		kernelVersion = kernelVersion[:i]
+	}
+	parts := strings.SplitN(kernelVersion, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	if major > kernelMajor {
+		return true
+	}
+	if major == kernelMajor && minor >= kernelMinor {
+		return true
+	}
+	return false
+}

--- a/internal/psi/version_test.go
+++ b/internal/psi/version_test.go
@@ -1,0 +1,68 @@
+package psi
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestServerVersionOK(t *testing.T) {
+	cases := []struct {
+		name  string
+		major string
+		minor string
+		want  bool
+	}{
+		{"GA 1.36", "1", "36", true},
+		{"future 1.37", "1", "37", true},
+		{"future 2.0", "2", "0", true},
+		{"beta 1.35", "1", "35", false},
+		{"beta 1.34", "1", "34", false},
+		{"pre-1.34 1.32", "1", "32", false},
+		{"managed suffix 1.36+", "1", "36+", true},
+		{"managed suffix 1.35+", "1", "35+", false},
+		{"empty", "", "", false},
+		{"unparseable", "v1", "x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &version.Info{Major: tc.major, Minor: tc.minor}
+			if got := ServerVersionOK(v); got != tc.want {
+				t.Errorf("ServerVersionOK(%q.%q) = %v, want %v", tc.major, tc.minor, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerVersionOK_NilInfo(t *testing.T) {
+	if ServerVersionOK(nil) {
+		t.Errorf("ServerVersionOK(nil) = true, want false")
+	}
+}
+
+func TestKernelVersionOK(t *testing.T) {
+	cases := []struct {
+		kernel string
+		want   bool
+	}{
+		{"5.15.0-72-generic", true},
+		{"5.4.0-1100-aws", true},
+		{"6.1.0-13-cloud-amd64", true},
+		{"7.0.0-14-generic", true},
+		{"4.20.0", true},
+		{"4.20", true},
+		{"4.19.0-15-generic", false},
+		{"4.18.0-477.el8", false},
+		{"3.10.0-1160.el7", false},
+		{"", false},
+		{"not-a-version", false},
+		{"4", false}, // single number, no minor
+	}
+	for _, tc := range cases {
+		t.Run(tc.kernel, func(t *testing.T) {
+			if got := KernelVersionOK(tc.kernel); got != tc.want {
+				t.Errorf("KernelVersionOK(%q) = %v, want %v", tc.kernel, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/userdir/dir.go
+++ b/internal/userdir/dir.go
@@ -1,6 +1,5 @@
 // Package userdir resolves and provisions the per-user ktop directory
-// (default ~/.ktop), where ktop stores its log file and, from v0.6.3,
-// its config file. Honor $KTOP_DIR to relocate the entire tree.
+// (default ~/.ktop). Set $KTOP_DIR to relocate the entire tree.
 package userdir
 
 import (

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vladimirvivien/ktop/internal/psi"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -145,6 +146,13 @@ func (k8s *Client) Username() string {
 
 func (k8s *Client) GetServerVersion() string {
 	return k8s.clusterVersion.String()
+}
+
+// PSIVersionOK reports whether the cluster's Kubernetes server version is at
+// or above the PSI GA release (1.36). Below 1.36 PSI values are best-effort
+// and may include the zero-emission bug on certain kubelet builds.
+func (k8s *Client) PSIVersionOK() bool {
+	return psi.ServerVersionOK(k8s.clusterVersion)
 }
 
 // AssertMetricsAvailable checks for available metrics server every 10th invocation.

--- a/k8s/summary_controller.go
+++ b/k8s/summary_controller.go
@@ -233,7 +233,23 @@ func (c *Controller) collectPrometheusEnhancedMetrics(ctx context.Context, summa
 		summary.LoadAverage1m += nodeMetrics.LoadAverage1m
 		summary.LoadAverage5m += nodeMetrics.LoadAverage5m
 		summary.LoadAverage15m += nodeMetrics.LoadAverage15m
+
+		// PSI: sum per-axis, divide after the loop for cluster-wide averages.
+		// Per-node values are surfaced separately in the Nodes table.
+		summary.AvgNodeCPUStallPct += nodeMetrics.PSI.CPUStallPct
+		summary.AvgNodeMemStallPct += nodeMetrics.PSI.MemStallPct
+		summary.AvgNodeIOStallPct += nodeMetrics.PSI.IOStallPct
 	}
+
+	// Average the PSI sums across all nodes.
+	if len(nodes) > 0 {
+		summary.AvgNodeCPUStallPct /= float64(len(nodes))
+		summary.AvgNodeMemStallPct /= float64(len(nodes))
+		summary.AvgNodeIOStallPct /= float64(len(nodes))
+	}
+
+	// PSIBeta is a cluster-wide capability flag; set once from the client.
+	summary.PSIBeta = !c.client.PSIVersionOK()
 
 	// Average the load across nodes (will be 0 without node_exporter)
 	if len(nodes) > 0 {

--- a/metrics/k8s/metrics_server_source.go
+++ b/metrics/k8s/metrics_server_source.go
@@ -11,8 +11,8 @@ import (
 	"github.com/vladimirvivien/ktop/metrics"
 	"github.com/vladimirvivien/ktop/prom"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 // historyDataPoint is a simple struct for storing historical values

--- a/metrics/prom/prom_source.go
+++ b/metrics/prom/prom_source.go
@@ -258,6 +258,75 @@ func isPodAggregateMemory(seriesKey string) bool {
 	return strings.Contains(seriesKey, `container=""`)
 }
 
+// isPSIWorkloadContainer returns true if the seriesKey represents a workload
+// container's PSI series. Excludes the pause container (container="POD") and
+// the pod-level aggregate (container="") — PSI is meaningful per workload
+// container, and the pod-level signal is computed as max across them.
+func isPSIWorkloadContainer(seriesKey string) bool {
+	if strings.Contains(seriesKey, `container="POD"`) {
+		return false
+	}
+	if strings.Contains(seriesKey, `container=""`) {
+		return false
+	}
+	return true
+}
+
+// calculatePSIMaxRate returns the maximum per-series stall percentage across
+// all matching series, in [0..100].
+//
+// PSI percentages from sibling containers are independent — a pod with one
+// 50%-stalled container and one idle container is not 25% stalled, it has a
+// 50%-stalled container. Use MAX, not SUM or MEAN.
+func (p *PromMetricsSource) calculatePSIMaxRate(metricName string, labelMatchers map[string]string, window time.Duration, filterFn func(seriesKey string) bool) (float64, error) {
+	now := time.Now()
+	start := now.Add(-window)
+
+	seriesSamples, err := p.store.QueryRangePerSeries(metricName, labelMatchers, start, now)
+	if err != nil {
+		return 0, err
+	}
+	if len(seriesSamples) == 0 {
+		return 0, fmt.Errorf("no matching series found for psi rate calculation")
+	}
+
+	var maxRate float64
+	validSeriesCount := 0
+
+	for seriesKey, samples := range seriesSamples {
+		if filterFn != nil && !filterFn(seriesKey) {
+			continue
+		}
+		if len(samples) < 2 {
+			continue
+		}
+
+		first := samples[0]
+		last := samples[len(samples)-1]
+
+		deltaValue := last.Value - first.Value
+		deltaTimeSec := float64(last.Timestamp-first.Timestamp) / 1000.0
+		if deltaTimeSec <= 0 {
+			continue
+		}
+		// Counter reset (container restart): treat last value as the rate basis.
+		if deltaValue < 0 {
+			deltaValue = last.Value
+		}
+
+		rate := deltaValue / deltaTimeSec
+		if rate > maxRate {
+			maxRate = rate
+		}
+		validSeriesCount++
+	}
+
+	if validSeriesCount == 0 {
+		return 0, fmt.Errorf("insufficient samples for psi rate calculation")
+	}
+	return maxRate * 100, nil
+}
+
 // queryLatestSumFiltered queries latest values and sums them, applying a filter function
 // This is used for memory metrics where we need to sum across workload containers only
 func (p *PromMetricsSource) queryLatestSumFiltered(metricName string, labelMatchers map[string]string, filterFn func(seriesKey string) bool) (float64, error) {
@@ -373,6 +442,29 @@ func (p *PromMetricsSource) GetNodeMetrics(ctx context.Context, nodeName string)
 		nodeMetrics.ContainerCount = int(containerCount)
 	}
 
+	// Pressure Stall Information for the node's root cgroup (id="/").
+	// Rate of a seconds counter over the window is fraction-stalled in [0..1];
+	// percent values stored on PSIMetrics multiply by 100.
+	const psiWindow = 40 * time.Second
+	if v, err := p.calculateCPURate("container_pressure_cpu_waiting_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.CPUStallPct = v * 100
+	}
+	if v, err := p.calculateCPURate("container_pressure_cpu_stalled_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.CPUStalledPct = v * 100
+	}
+	if v, err := p.calculateCPURate("container_pressure_memory_waiting_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.MemStallPct = v * 100
+	}
+	if v, err := p.calculateCPURate("container_pressure_memory_stalled_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.MemStalledPct = v * 100
+	}
+	if v, err := p.calculateCPURate("container_pressure_io_waiting_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.IOStallPct = v * 100
+	}
+	if v, err := p.calculateCPURate("container_pressure_io_stalled_seconds_total", labelMatchers, psiWindow); err == nil {
+		nodeMetrics.PSI.IOStalledPct = v * 100
+	}
+
 	return nodeMetrics, nil
 }
 
@@ -430,6 +522,29 @@ func (p *PromMetricsSource) GetPodMetrics(ctx context.Context, namespace, podNam
 	// Only add container metrics if we got at least one metric
 	if containerMetrics.CPUUsage != nil || containerMetrics.MemoryUsage != nil {
 		podMetrics.Containers = append(podMetrics.Containers, containerMetrics)
+	}
+
+	// Pressure Stall Information at pod scope. PSI percentages don't sum
+	// meaningfully across containers; pod-level signal is the worst-affected
+	// container per axis.
+	const psiWindow = 40 * time.Second
+	if v, err := p.calculatePSIMaxRate("container_pressure_cpu_waiting_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.CPUStallPct = v
+	}
+	if v, err := p.calculatePSIMaxRate("container_pressure_cpu_stalled_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.CPUStalledPct = v
+	}
+	if v, err := p.calculatePSIMaxRate("container_pressure_memory_waiting_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.MemStallPct = v
+	}
+	if v, err := p.calculatePSIMaxRate("container_pressure_memory_stalled_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.MemStalledPct = v
+	}
+	if v, err := p.calculatePSIMaxRate("container_pressure_io_waiting_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.IOStallPct = v
+	}
+	if v, err := p.calculatePSIMaxRate("container_pressure_io_stalled_seconds_total", labelMatchers, psiWindow, isPSIWorkloadContainer); err == nil {
+		podMetrics.PSI.IOStalledPct = v
 	}
 
 	return podMetrics, nil

--- a/metrics/prom/prom_source_test.go
+++ b/metrics/prom/prom_source_test.go
@@ -708,3 +708,159 @@ func TestGetMetricsForPod_NotImplemented(t *testing.T) {
 		t.Errorf("Expected pod name 'test-pod', got '%s'", metrics.PodName)
 	}
 }
+
+// psiTestStore is a minimal MetricsStore that returns caller-supplied
+// per-series sample pairs verbatim. Used to exercise calculatePSIMaxRate's
+// MAX semantics, which the shared MockMetricsStore cannot demonstrate
+// (its QueryRangePerSeries forces a fixed 4.0 delta on every series).
+type psiTestStore struct {
+	samples map[string]map[string][]*prom.MetricSample // metric -> seriesKey -> samples
+}
+
+func newPSITestStore() *psiTestStore {
+	return &psiTestStore{samples: map[string]map[string][]*prom.MetricSample{}}
+}
+
+func (s *psiTestStore) set(metric, seriesKey string, first, last float64, windowSec int64) {
+	now := time.Now()
+	if s.samples[metric] == nil {
+		s.samples[metric] = map[string][]*prom.MetricSample{}
+	}
+	s.samples[metric][seriesKey] = []*prom.MetricSample{
+		{Timestamp: now.Add(-time.Duration(windowSec) * time.Second).UnixMilli(), Value: first},
+		{Timestamp: now.UnixMilli(), Value: last},
+	}
+}
+
+func (s *psiTestStore) AddMetrics(*prom.ScrapedMetrics) error                     { return nil }
+func (s *psiTestStore) QueryLatest(string, map[string]string) (float64, error)    { return 0, nil }
+func (s *psiTestStore) QueryLatestSum(string, map[string]string) (float64, error) { return 0, nil }
+func (s *psiTestStore) QueryRange(string, map[string]string, time.Time, time.Time) ([]*prom.MetricSample, error) {
+	return nil, nil
+}
+func (s *psiTestStore) QueryRangePerSeries(metric string, _ map[string]string, _, _ time.Time) (map[string][]*prom.MetricSample, error) {
+	series, ok := s.samples[metric]
+	if !ok {
+		return nil, fmt.Errorf("metric %s not found", metric)
+	}
+	return series, nil
+}
+func (s *psiTestStore) GetMetricNames() []string       { return nil }
+func (s *psiTestStore) GetLabelValues(string) []string { return nil }
+func (s *psiTestStore) Cleanup() error                 { return nil }
+
+func TestCalculatePSIMaxRate(t *testing.T) {
+	const metric = "container_pressure_cpu_waiting_seconds_total"
+	type series struct {
+		key         string
+		first, last float64
+	}
+	cases := []struct {
+		name    string
+		series  []series
+		filter  func(string) bool
+		wantPct float64
+		wantErr bool
+	}{
+		{
+			name: "single workload series, 10% stall",
+			series: []series{
+				{`{container="app", pod="p"}`, 0, 4},
+			},
+			filter:  isPSIWorkloadContainer,
+			wantPct: 10,
+		},
+		{
+			name: "two workload series, max wins",
+			series: []series{
+				{`{container="app",    pod="p"}`, 0, 4},  // 10%
+				{`{container="worker", pod="p"}`, 0, 12}, // 30%
+			},
+			filter:  isPSIWorkloadContainer,
+			wantPct: 30,
+		},
+		{
+			name: "pause container ignored even when highest",
+			series: []series{
+				{`{container="POD", pod="p"}`, 0, 40}, // 100% if counted
+				{`{container="app", pod="p"}`, 0, 4},  // 10%
+			},
+			filter:  isPSIWorkloadContainer,
+			wantPct: 10,
+		},
+		{
+			name: "pod aggregate ignored even when highest",
+			series: []series{
+				{`{container="",    pod="p"}`, 0, 40},
+				{`{container="app", pod="p"}`, 0, 4},
+			},
+			filter:  isPSIWorkloadContainer,
+			wantPct: 10,
+		},
+		{
+			name: "counter reset uses last value as basis",
+			series: []series{
+				// last < first → reset detected → rate = last/40s = 0.05 → 5%
+				{`{container="app", pod="p"}`, 100, 2},
+			},
+			filter:  isPSIWorkloadContainer,
+			wantPct: 5,
+		},
+		{
+			name:    "no series → error",
+			series:  nil,
+			filter:  isPSIWorkloadContainer,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newPSITestStore()
+			for _, s := range tc.series {
+				store.set(metric, s.key, s.first, s.last, 40)
+			}
+			cfg := DefaultPromConfig()
+			src, err := NewPromMetricsSource(&rest.Config{}, cfg)
+			if err != nil {
+				t.Fatalf("NewPromMetricsSource: %v", err)
+			}
+			src.store = store
+			src.setHealthyForTesting(true)
+
+			got, err := src.calculatePSIMaxRate(metric, nil, 40*time.Second, tc.filter)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantPct {
+				t.Errorf("got %v%%, want %v%%", got, tc.wantPct)
+			}
+		})
+	}
+}
+
+func TestIsPSIWorkloadContainer(t *testing.T) {
+	cases := []struct {
+		seriesKey string
+		want      bool
+	}{
+		{`{container="app", pod="p"}`, true},
+		{`{container="worker", pod="p"}`, true},
+		{`{container="POD", pod="p"}`, false}, // pause
+		{`{container="", pod="p"}`, false},    // pod aggregate
+		{`{pod="p"}`, true},                   // no container label = pass
+	}
+	for _, tc := range cases {
+		t.Run(tc.seriesKey, func(t *testing.T) {
+			if got := isPSIWorkloadContainer(tc.seriesKey); got != tc.want {
+				t.Errorf("isPSIWorkloadContainer(%q) = %v, want %v", tc.seriesKey, got, tc.want)
+			}
+		})
+	}
+}

--- a/metrics/source.go
+++ b/metrics/source.go
@@ -72,6 +72,29 @@ type MetricsSource interface {
 	SupportsHistory() bool
 }
 
+// PSIMetrics holds Pressure Stall Information for a node, pod, or container.
+// Values are percentages [0..100] of wall time spent stalled on the resource
+// during the most recent scrape window.
+//
+// A zero value is indistinguishable at this layer between a genuinely idle
+// cgroup and a host kernel that does not expose PSI (kernel <4.20, cgroup v1,
+// or an unpatched kubelet hitting kubernetes/kubernetes#136333). Callers that
+// need to interpret zeros should consult the node's kernel version and the
+// cluster's server version separately.
+type PSIMetrics struct {
+	// "Waiting" axis — at least one task in the cgroup blocked on the
+	// resource. This is the value rendered in the STALL column.
+	CPUStallPct float64
+	MemStallPct float64
+	IOStallPct  float64
+
+	// "Stalled" axis — every task blocked. Not every kernel emits the
+	// CPU-stalled counter; absent values arrive here as zero.
+	CPUStalledPct float64
+	MemStalledPct float64
+	IOStalledPct  float64
+}
+
 // NodeMetrics represents resource usage metrics for a Kubernetes node.
 // Contains both basic metrics (CPU, memory) available from all sources,
 // and enhanced metrics (network, load, disk) available only from Prometheus.
@@ -123,6 +146,10 @@ type NodeMetrics struct {
 
 	// ContainerCount is the total number of containers running on this node
 	ContainerCount int
+
+	// PSI captures resource pressure for the node's root cgroup.
+	// Zero when the source does not provide PSI (e.g., metrics-server).
+	PSI PSIMetrics
 }
 
 // PodMetrics represents resource usage metrics for a Kubernetes pod.
@@ -139,6 +166,11 @@ type PodMetrics struct {
 
 	// Containers contains metrics for each container in the pod
 	Containers []ContainerMetrics
+
+	// PSI captures the worst-affected axis across containers in the pod.
+	// Computed as max(container.PSI.*) per axis — a pod with any heavily
+	// stalled container surfaces that container's stall percentage.
+	PSI PSIMetrics
 }
 
 // ContainerMetrics represents resource usage metrics for a single container.
@@ -166,6 +198,10 @@ type ContainerMetrics struct {
 
 	// RestartCount is the number of times this container has restarted
 	RestartCount int
+
+	// PSI captures resource pressure for this container's cgroup.
+	// Zero when the source does not provide PSI.
+	PSI PSIMetrics
 }
 
 // SourceInfo provides metadata about a metrics source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Metrics:
     - Prometheus: prometheus.md
     - Metrics Server: metrics-server.md
+    - PSI (Pressure Stall): psi.md
 
 extra:
   social:

--- a/prom/types.go
+++ b/prom/types.go
@@ -25,7 +25,10 @@ const (
 
 // DefaultMetricAllowlist contains only the metrics ktop actually uses.
 // All other metrics are filtered out during scraping to reduce memory usage.
+// The scraper filters by exact name match; adding entries here is sufficient
+// to make them available to the store.
 var DefaultMetricAllowlist = map[string]bool{
+	// CPU, memory, network, disk — used by node/pod tables and sparklines.
 	"container_cpu_usage_seconds_total":      true,
 	"container_memory_working_set_bytes":     true,
 	"container_network_receive_bytes_total":  true,
@@ -34,6 +37,16 @@ var DefaultMetricAllowlist = map[string]bool{
 	"container_fs_writes_bytes_total":        true,
 	"kubelet_running_pods":                   true,
 	"container_count":                        true,
+
+	// Pressure Stall Information (PSI). The "waiting" axis carries the
+	// dominant stall signal; "stalled" is for detail-page rendering. Not
+	// every kernel emits container_pressure_cpu_stalled_seconds_total.
+	"container_pressure_cpu_waiting_seconds_total":    true,
+	"container_pressure_cpu_stalled_seconds_total":    true,
+	"container_pressure_memory_waiting_seconds_total": true,
+	"container_pressure_memory_stalled_seconds_total": true,
+	"container_pressure_io_waiting_seconds_total":     true,
+	"container_pressure_io_stalled_seconds_total":     true,
 }
 
 // MetricSample represents a single metric data point

--- a/ui/icons.go
+++ b/ui/icons.go
@@ -9,19 +9,19 @@ var Icons = struct {
 	BargraphLBorder  string
 	BargraphRBorder  string
 	Factory          string
-	Battery         string
-	Package         string
-	Anchor          string
-	Rocket          string
-	Thermometer     string
-	Sun             string
-	Knobs           string
-	Drum            string
-	M               string
-	Plane           string
-	Controller      string
-	Clock           string
-	TrafficLight    string
+	Battery          string
+	Package          string
+	Anchor           string
+	Rocket           string
+	Thermometer      string
+	Sun              string
+	Knobs            string
+	Drum             string
+	M                string
+	Plane            string
+	Controller       string
+	Clock            string
+	TrafficLight     string
 	// Status icons for visual indicators (using strings for multi-byte emojis)
 	Healthy   string
 	Error     string
@@ -41,19 +41,19 @@ var Icons = struct {
 	BargraphLBorder:  "[",
 	BargraphRBorder:  "]",
 	Factory:          "🏭",
-	Battery:         "🔋",
-	Package:         "📦",
-	Anchor:          "⚓",
-	Rocket:          "🚀",
-	Thermometer:     "🌡",
-	Sun:             "☀",
-	Knobs:           "🎛",
-	Drum:            "🥁",
-	M:               "Ⓜ",
-	Plane:           "🛩",
-	Controller:      "🛂",
-	Clock:           "⏰",
-	TrafficLight:    "🚦",
+	Battery:          "🔋",
+	Package:          "📦",
+	Anchor:           "⚓",
+	Rocket:           "🚀",
+	Thermometer:      "🌡",
+	Sun:              "☀",
+	Knobs:            "🎛",
+	Drum:             "🥁",
+	M:                "Ⓜ",
+	Plane:            "🛩",
+	Controller:       "🛂",
+	Clock:            "⏰",
+	TrafficLight:     "🚦",
 	// Status icons
 	Healthy:   "✅",
 	Error:     "❌",

--- a/views/container/detail.go
+++ b/views/container/detail.go
@@ -64,7 +64,7 @@ type DetailPanel struct {
 	// Filter state
 	filterMode  bool
 	filterQuery string
-	allLogs     []string    // Store full logs for filtering
+	allLogs     []string // Store full logs for filtering
 	filterInput *tview.InputField
 
 	// Streaming control
@@ -92,10 +92,10 @@ type DetailPanel struct {
 func NewDetailPanel() *DetailPanel {
 	p := &DetailPanel{
 		root:             tview.NewFlex().SetDirection(tview.FlexRow),
-		following:        true, // Default to streaming (auto-tail)
+		following:        true,  // Default to streaming (auto-tail)
 		wrapText:         false, // Default to no wrap
-		tailLines:        100,  // Default tail lines (fast initial load)
-		totalLinesLoaded: 100,  // Track cumulative for "load more"
+		tailLines:        100,   // Default tail lines (fast initial load)
+		totalLinesLoaded: 100,   // Track cumulative for "load more"
 	}
 
 	p.setupInputCapture()

--- a/views/model/node_model.go
+++ b/views/model/node_model.go
@@ -3,6 +3,8 @@ package model
 import (
 	"sort"
 
+	"github.com/vladimirvivien/ktop/internal/psi"
+	"github.com/vladimirvivien/ktop/metrics"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +52,14 @@ type NodeModel struct {
 
 	UsageCpuQty *resource.Quantity
 	UsageMemQty *resource.Quantity
+
+	// PSI carries pressure stall percentages for the node's root cgroup.
+	// Zero when the metrics source does not provide PSI (e.g., metrics-server).
+	PSI metrics.PSIMetrics
+
+	// PSIKernelSupported is true when the node's Linux kernel is >= 4.20.
+	// PSI values from a node with this set to false are not reliable.
+	PSIKernelSupported bool
 }
 
 func NewNodeModel(node *coreV1.Node, metrics *v1beta1.NodeMetrics) *NodeModel {
@@ -85,6 +95,8 @@ func NewNodeModel(node *coreV1.Node, metrics *v1beta1.NodeMetrics) *NodeModel {
 
 		UsageCpuQty: metrics.Usage.Cpu(),
 		UsageMemQty: metrics.Usage.Memory(),
+
+		PSIKernelSupported: psi.KernelVersionOK(node.Status.NodeInfo.KernelVersion),
 	}
 }
 
@@ -290,6 +302,26 @@ func SortNodeModelsBy(nodes []NodeModel, column string, ascending bool) {
 				return nodes[i].Name < nodes[j].Name
 			}
 			return memI < memJ
+		}
+
+	case "STALL":
+		// Sort by the dominant stall axis (max of CPU/MEM/IO waiting %).
+		sortFunc = func(i, j int) bool {
+			dom := func(n NodeModel) float64 {
+				m := n.PSI.CPUStallPct
+				if n.PSI.MemStallPct > m {
+					m = n.PSI.MemStallPct
+				}
+				if n.PSI.IOStallPct > m {
+					m = n.PSI.IOStallPct
+				}
+				return m
+			}
+			si, sj := dom(nodes[i]), dom(nodes[j])
+			if si == sj {
+				return nodes[i].Name < nodes[j].Name
+			}
+			return si < sj
 		}
 
 	default:

--- a/views/model/pod_model.go
+++ b/views/model/pod_model.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	ktopmetrics "github.com/vladimirvivien/ktop/metrics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,14 @@ type PodModel struct {
 	Restarts        int
 	Volumes         int
 	VolMounts       int
+
+	// PSI carries pressure stall percentages for this pod (max across its
+	// containers, per axis). Zero when the metrics source does not provide PSI.
+	PSI ktopmetrics.PSIMetrics
+
+	// NodePSIKernelSupported mirrors NodeModel.PSIKernelSupported for the pod's
+	// node, denormalized here to avoid a per-row node lookup at render time.
+	NodePSIKernelSupported bool
 }
 
 type PodContainerSummary struct {
@@ -208,6 +217,27 @@ func SortPodModelsBy(pods []PodModel, column string, ascending bool) {
 				return pods[i].Name < pods[j].Name
 			}
 			return memI < memJ
+		}
+
+	case "STALL":
+		// Sort by the dominant stall axis (max of CPU/MEM/IO waiting %).
+		// Same axis selection the STALL column displays.
+		sortFunc = func(i, j int) bool {
+			dom := func(p PodModel) float64 {
+				m := p.PSI.CPUStallPct
+				if p.PSI.MemStallPct > m {
+					m = p.PSI.MemStallPct
+				}
+				if p.PSI.IOStallPct > m {
+					m = p.PSI.IOStallPct
+				}
+				return m
+			}
+			si, sj := dom(pods[i]), dom(pods[j])
+			if si == sj {
+				return pods[i].Name < pods[j].Name
+			}
+			return si < sj
 		}
 
 	default:

--- a/views/model/summary_model.go
+++ b/views/model/summary_model.go
@@ -57,15 +57,26 @@ type ClusterSummary struct {
 	DiskWriteRate  float64 // Bytes/sec written
 
 	// Health indicators
-	ContainerRestarts int     // Total container restarts (cumulative)
-	FailedPods        int     // Pods in Failed state
-	EvictedPods       int     // Pods that were evicted
-	OOMKillCount      int     // OOM kills
-	NodePressureCount int     // Nodes with memory/disk/PID pressure
+	ContainerRestarts   int     // Total container restarts (cumulative)
+	FailedPods          int     // Pods in Failed state
+	EvictedPods         int     // Pods that were evicted
+	OOMKillCount        int     // OOM kills
+	NodePressureCount   int     // Nodes with memory/disk/PID pressure
 	CPUThrottledPercent float64 // Avg CPU throttling across containers
 
 	// Load averages (cluster-wide average)
 	LoadAverage1m  float64
 	LoadAverage5m  float64
 	LoadAverage15m float64
+
+	// PSI stall percentages averaged across nodes — cluster-wide health.
+	// The summary strip renders the dominant axis (max of the three averages).
+	// Zero when the metrics source does not provide PSI.
+	AvgNodeCPUStallPct float64
+	AvgNodeMemStallPct float64
+	AvgNodeIOStallPct  float64
+
+	// PSIBeta is true when the cluster's Kubernetes version is below 1.36 (GA).
+	// Surfaced by the UI to mark stall values as best-effort.
+	PSIBeta bool
 }

--- a/views/node/detail.go
+++ b/views/node/detail.go
@@ -35,9 +35,9 @@ type DetailPanel struct {
 	lastInfoHeaderHeight int
 
 	// Focus management for tab cycling
-	focusedChildIdx int              // Index of currently focused child (-1 = none)
-	focusableItems  []tview.Primitive // Ordered list of focusable primitives
-	focusablePanels []*tview.Flex     // Corresponding parent panels (for border updates)
+	focusedChildIdx int                     // Index of currently focused child (-1 = none)
+	focusableItems  []tview.Primitive       // Ordered list of focusable primitives
+	focusablePanels []*tview.Flex           // Corresponding parent panels (for border updates)
 	setAppFocus     func(p tview.Primitive) // Callback to set tview app focus
 
 	// Sub-panels
@@ -159,7 +159,7 @@ func (p *DetailPanel) Layout(_ interface{}) {
 		p.podsPanel.SetBorderColor(tcell.ColorLightGray)
 
 		p.podsTable = tview.NewTable()
-		p.podsTable.SetFixed(1, 0) // Fixed header row
+		p.podsTable.SetFixed(1, 0)              // Fixed header row
 		p.podsTable.SetSelectable(false, false) // Start unselectable, enable on focus
 		p.podsTable.SetBorder(false)
 		p.podsTable.SetBorders(false)
@@ -260,7 +260,7 @@ func (p *DetailPanel) DrawBody(data interface{}) {
 	}
 	if newNodeName != p.currentNodeName {
 		p.resetSparklines()
-		p.peakNetRate = 0  // Reset adaptive scaling peaks
+		p.peakNetRate = 0 // Reset adaptive scaling peaks
 		p.peakDiskRate = 0
 		p.currentNodeName = newNodeName
 

--- a/views/overview/main_panel.go
+++ b/views/overview/main_panel.go
@@ -53,8 +53,8 @@ type MainPanel struct {
 	viewState *ViewStateManager
 
 	// Dynamic layout tracking
-	lastHeightCategory  int // 0=small, 1=medium, 2=large, 3=extraLarge - for detecting resize category changes
-	lastTerminalHeight  int // Track height for dynamic resizing in ExtraLarge category
+	lastHeightCategory int // 0=small, 1=medium, 2=large, 3=extraLarge - for detecting resize category changes
+	lastTerminalHeight int // Track height for dynamic resizing in ExtraLarge category
 }
 
 func New(app *application.Application, title string) *MainPanel {
@@ -79,8 +79,8 @@ func NewWithColumnOptions(app *application.Application, title string, showAllCol
 
 func (p *MainPanel) Layout(data interface{}) {
 	// Define the default columns
-	allNodeColumns := []string{"NAME", "STATUS", "RST", "PODS", "TAINTS", "PRESSURE", "IP", "VOLS", "DISK", "CPU", "MEM"}
-	allPodColumns := []string{"NAMESPACE", "POD", "READY", "STATUS", "RST", "AGE", "VOLS", "IP", "NODE", "CPU", "MEMORY"}
+	allNodeColumns := []string{"NAME", "STATUS", "RST", "PODS", "TAINTS", "PRESSURE", "IP", "VOLS", "DISK", "CPU", "MEM", "STALL"}
+	allPodColumns := []string{"NAMESPACE", "POD", "READY", "STATUS", "RST", "AGE", "VOLS", "IP", "NODE", "CPU", "MEMORY", "STALL"}
 
 	// Use filtered columns if specified
 	nodeColumnsToDisplay := allNodeColumns
@@ -677,6 +677,7 @@ func (p *MainPanel) refreshNodeView(ctx context.Context, models []model.NodeMode
 				// Update the model's metrics fields
 				existingModel.UsageCpuQty = nodeMetrics.CPUUsage
 				existingModel.UsageMemQty = nodeMetrics.MemoryUsage
+				existingModel.PSI = nodeMetrics.PSI
 			}
 			// If err != nil, graceful degradation: keep existing model as-is
 		}
@@ -733,6 +734,15 @@ func (p *MainPanel) refreshPods(ctx context.Context, models []model.PodModel) er
 		allPodMetrics, err = p.metricsSource.GetAllPodMetrics(ctx)
 	}
 
+	// Build a map for each pod's node-kernel-PSI-support flag, so the pod
+	// table can render the per-row warning glyph without a separate lookup.
+	// Snapshot of cachedNodeModels — a transient race here yields at most a
+	// one-cycle warning delay, which is acceptable.
+	nodeKernelSupport := make(map[string]bool, len(p.cachedNodeModels))
+	for _, n := range p.cachedNodeModels {
+		nodeKernelSupport[n.Name] = n.PSIKernelSupported
+	}
+
 	// Update models with metrics first (before caching)
 	updatedModels := models
 	if p.metricsSource != nil && err == nil {
@@ -760,7 +770,9 @@ func (p *MainPanel) refreshPods(ctx context.Context, models []model.PodModel) er
 					existingModel.PodUsageCpuQty = totalCpu
 					existingModel.PodUsageMemQty = totalMem
 				}
+				existingModel.PSI = podMetrics.PSI
 			}
+			existingModel.NodePSIKernelSupported = nodeKernelSupport[existingModel.Node]
 			updatedModels = append(updatedModels, existingModel)
 		}
 	}

--- a/views/overview/node_panel.go
+++ b/views/overview/node_panel.go
@@ -203,6 +203,7 @@ func (p *nodePanel) formatColumnHeader(col string) string {
 		"DISK":     'd',
 		"CPU":      'c',
 		"MEM":      'm',
+		"STALL":    'l',
 	}
 
 	// Find the shortcut key for this column
@@ -345,6 +346,7 @@ func (p *nodePanel) handleSortKey(key rune) bool {
 		'd': "DISK",
 		'c': "CPU",
 		'm': "MEM",
+		'l': "STALL",
 	}
 
 	columnName, exists := keyToColumn[key]
@@ -648,6 +650,16 @@ func (p *nodePanel) DrawBody(data interface{}) {
 						Text:  memMetrics,
 						Color: rowColor,
 						Align: tview.AlignLeft,
+					},
+				)
+
+			case "STALL":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:     renderStallCell(node.PSI, node.PSIKernelSupported),
+						Align:    tview.AlignLeft,
+						MaxWidth: 12,
 					},
 				)
 			}

--- a/views/overview/pod_panel.go
+++ b/views/overview/pod_panel.go
@@ -197,13 +197,14 @@ func (p *podPanel) formatColumnHeader(col string) string {
 		"POD":       'p',
 		"READY":     'r',
 		"STATUS":    's',
-		"RST":  't', // Uses 't' at position 3
+		"RST":       't', // Uses 't' at position 3
 		"AGE":       'a',
 		"VOLS":      'v',
 		"IP":        'i',
 		"NODE":      'o', // Uses 'o' at position 1
 		"CPU":       'c',
 		"MEMORY":    'm',
+		"STALL":     'l', // 'L' at position 3 to avoid 's' (STATUS) collision
 	}
 
 	// Find the shortcut key for this column
@@ -333,6 +334,7 @@ func (p *podPanel) handleSortKey(key rune) bool {
 		'o': "NODE",
 		'c': "CPU",
 		'm': "MEMORY",
+		'l': "STALL",
 	}
 
 	columnName, exists := keyToColumn[key]
@@ -624,6 +626,16 @@ func (p *podPanel) DrawBody(data interface{}) {
 						Text:  memMetrics,
 						Color: rowColor,
 						Align: tview.AlignLeft,
+					},
+				)
+
+			case "STALL":
+				p.list.SetCell(
+					rowIdx, colIdx,
+					&tview.TableCell{
+						Text:     renderStallCell(pod.PSI, pod.NodePSIKernelSupported),
+						Align:    tview.AlignLeft,
+						MaxWidth: 12,
 					},
 				)
 			}

--- a/views/overview/psi_cell.go
+++ b/views/overview/psi_cell.go
@@ -1,0 +1,66 @@
+package overview
+
+import (
+	"fmt"
+
+	"github.com/vladimirvivien/ktop/metrics"
+)
+
+// renderStallCell returns the rendered text for a STALL column cell.
+//
+// The dominant axis is the largest of the three "waiting" percentages
+// (CPU/MEM/IO). Values below 0.01% render as a gray dot. Color thresholds:
+//
+//	   < 2%   green   — healthy
+//	2 – 10%   yellow  — minor pressure
+//	10 – 25%  orange  — meaningful pressure
+//	  >= 25%  red     — severe pressure
+//
+// When kernelSupported is false (node Linux kernel < 4.20), the cell is
+// prefixed with "⚠ " in yellow regardless of the value, because PSI data
+// from those nodes is not reliable.
+func renderStallCell(psi metrics.PSIMetrics, kernelSupported bool) string {
+	cpu, mem, io := psi.CPUStallPct, psi.MemStallPct, psi.IOStallPct
+
+	max := cpu
+	label := "CPU"
+	if mem > max {
+		max = mem
+		label = "MEM"
+	}
+	if io > max {
+		max = io
+		label = "IO"
+	}
+
+	var core string
+	switch {
+	case max < 0.01:
+		core = "[gray]·[-]"
+	case max < 1.0:
+		// Two decimals so 0.24% doesn't collide with 0.04% visually.
+		core = fmt.Sprintf("[%s]%s %.2f%%[-]", stallColor(max), label, max)
+	case max < 10.0:
+		core = fmt.Sprintf("[%s]%s %.1f%%[-]", stallColor(max), label, max)
+	default:
+		core = fmt.Sprintf("[%s]%s %.0f%%[-]", stallColor(max), label, max)
+	}
+
+	if !kernelSupported {
+		return "[yellow]⚠ [-]" + core
+	}
+	return core
+}
+
+func stallColor(pct float64) string {
+	switch {
+	case pct < 2:
+		return "green"
+	case pct < 10:
+		return "yellow"
+	case pct < 25:
+		return "orange"
+	default:
+		return "red"
+	}
+}

--- a/views/overview/psi_cell_test.go
+++ b/views/overview/psi_cell_test.go
@@ -1,0 +1,111 @@
+package overview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vladimirvivien/ktop/metrics"
+)
+
+func TestRenderStallCell(t *testing.T) {
+	cases := []struct {
+		name            string
+		psi             metrics.PSIMetrics
+		kernelSupported bool
+		wantContains    []string
+		wantNotContain  []string
+	}{
+		{
+			name:            "zero PSI renders gray dot",
+			psi:             metrics.PSIMetrics{},
+			kernelSupported: true,
+			wantContains:    []string{"[gray]·[-]"},
+			wantNotContain:  []string{"⚠", "CPU", "MEM", "IO"},
+		},
+		{
+			name:            "round-to-zero (< 0.01%) renders gray dot",
+			psi:             metrics.PSIMetrics{CPUStallPct: 0.001},
+			kernelSupported: true,
+			wantContains:    []string{"[gray]·[-]"},
+		},
+		{
+			name:            "sub-1% stall keeps 2 decimals",
+			psi:             metrics.PSIMetrics{IOStallPct: 0.24},
+			kernelSupported: true,
+			wantContains:    []string{"[green]IO 0.24%"},
+		},
+		{
+			name:            "CPU dominant ~1.5% → green, 1 decimal",
+			psi:             metrics.PSIMetrics{CPUStallPct: 1.5, MemStallPct: 0.5},
+			kernelSupported: true,
+			wantContains:    []string{"[green]CPU 1.5%"},
+		},
+		{
+			name:            "MEM dominant 7% → yellow",
+			psi:             metrics.PSIMetrics{CPUStallPct: 1, MemStallPct: 7, IOStallPct: 3},
+			kernelSupported: true,
+			wantContains:    []string{"[yellow]MEM 7.0%"},
+		},
+		{
+			name:            "IO dominant 18% → orange, integer",
+			psi:             metrics.PSIMetrics{CPUStallPct: 5, IOStallPct: 18},
+			kernelSupported: true,
+			wantContains:    []string{"[orange]IO 18%"},
+		},
+		{
+			name:            "severe pressure → red",
+			psi:             metrics.PSIMetrics{CPUStallPct: 45},
+			kernelSupported: true,
+			wantContains:    []string{"[red]CPU 45%"},
+		},
+		{
+			name:            "unsupported kernel adds warning glyph",
+			psi:             metrics.PSIMetrics{CPUStallPct: 5},
+			kernelSupported: false,
+			wantContains:    []string{"[yellow]⚠ [-]", "CPU 5.0%"},
+		},
+		{
+			name:            "unsupported kernel with zero PSI still warns",
+			psi:             metrics.PSIMetrics{},
+			kernelSupported: false,
+			wantContains:    []string{"[yellow]⚠ [-]", "[gray]·[-]"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderStallCell(tc.psi, tc.kernelSupported)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("got %q, want to contain %q", got, want)
+				}
+			}
+			for _, want := range tc.wantNotContain {
+				if strings.Contains(got, want) {
+					t.Errorf("got %q, should NOT contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestStallColorThresholds(t *testing.T) {
+	cases := []struct {
+		pct  float64
+		want string
+	}{
+		{0.5, "green"},
+		{1.99, "green"},
+		{2.0, "yellow"},
+		{9.99, "yellow"},
+		{10.0, "orange"},
+		{24.99, "orange"},
+		{25.0, "red"},
+		{99.0, "red"},
+	}
+	for _, tc := range cases {
+		if got := stallColor(tc.pct); got != tc.want {
+			t.Errorf("stallColor(%v) = %q, want %q", tc.pct, got, tc.want)
+		}
+	}
+}

--- a/views/overview/summary_panel.go
+++ b/views/overview/summary_panel.go
@@ -321,14 +321,30 @@ func (p *clusterSummaryPanel) drawEnhancedStats(summary model.ClusterSummary) {
 		pressureColor = "red"
 	}
 
+	stallText := formatSummaryStall(summary)
+
 	enhancedText := fmt.Sprintf(
-		"[yellow]Restarts: [%s]%d[yellow] │ Failures: [%s]%d[yellow] │ Evicted: [%s]%d[yellow] │ Pressure: [%s]%d",
+		"[yellow]Restarts: [%s]%d[yellow] │ Failures: [%s]%d[yellow] │ Evicted: [%s]%d[yellow] │ Pressure: [%s]%d[yellow] │ Stall: %s",
 		restartsColor, summary.ContainerRestarts,
 		failuresColor, summary.FailedPods,
 		evictedColor, summary.EvictedPods,
 		pressureColor, summary.NodePressureCount,
+		stallText,
 	)
 	p.enhancedStats.SetText(enhancedText)
+}
+
+// formatSummaryStall renders the cluster-wide PSI cell for the summary strip.
+// Shows the dominant axis across nodes (max of CPU/MEM/IO cluster averages),
+// with the same format and color thresholds as the per-row STALL column. The
+// beta caveat for K8s versions below 1.36 (GA) is documented in docs/psi.md.
+func formatSummaryStall(s model.ClusterSummary) string {
+	psi := metrics.PSIMetrics{
+		CPUStallPct: s.AvgNodeCPUStallPct,
+		MemStallPct: s.AvgNodeMemStallPct,
+		IOStallPct:  s.AvgNodeIOStallPct,
+	}
+	return renderStallCell(psi, true)
 }
 
 func (p *clusterSummaryPanel) DrawFooter(data interface{}) {}

--- a/views/pod/detail.go
+++ b/views/pod/detail.go
@@ -166,8 +166,8 @@ func (p *DetailPanel) Layout(_ interface{}) {
 
 		// Center column: vertical flex with Conditions+Events and Resources
 		centerColumn := tview.NewFlex().SetDirection(tview.FlexRow)
-		centerColumn.AddItem(p.middleDetailTable, 0, 1, false)  // Conditions+Events (flex)
-		centerColumn.AddItem(p.resourcesTextView, 3, 0, false)  // Resources (fixed 3 rows)
+		centerColumn.AddItem(p.middleDetailTable, 0, 1, false) // Conditions+Events (flex)
+		centerColumn.AddItem(p.resourcesTextView, 3, 0, false) // Resources (fixed 3 rows)
 
 		// Right column: vertical flex with Labels and Annotations
 		rightColumn := tview.NewFlex().SetDirection(tview.FlexRow)
@@ -186,7 +186,7 @@ func (p *DetailPanel) Layout(_ interface{}) {
 		p.containersPanel.SetBorderColor(tcell.ColorLightGray)
 
 		p.containersTable = tview.NewTable()
-		p.containersTable.SetFixed(1, 0) // Fixed header row
+		p.containersTable.SetFixed(1, 0)              // Fixed header row
 		p.containersTable.SetSelectable(false, false) // Start unselectable, enable on focus
 		p.containersTable.SetBorder(false)
 		p.containersTable.SetBorders(false)

--- a/views/pod/logs.go
+++ b/views/pod/logs.go
@@ -49,9 +49,9 @@ type LogsPanel struct {
 func NewLogsPanel() *LogsPanel {
 	p := &LogsPanel{
 		root:      tview.NewFlex().SetDirection(tview.FlexRow),
-		following: true,  // Default to following
-		wrapText:  true,  // Default to wrapped
-		tailLines: 1000,  // Default tail lines
+		following: true, // Default to following
+		wrapText:  true, // Default to wrapped
+		tailLines: 1000, // Default tail lines
 	}
 
 	p.setupInputCapture()


### PR DESCRIPTION
This PR adds PSI metrics support to `ktop` to provide resource contention metrics from prometheus. It adds a `STALL` column on the `Overview Nodes` and `Pods` tables. It also adds a cluster-wide `Stall` metrics the summary header in the Overview.

Fixes #150 